### PR TITLE
Suggestion: Some cleanup

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -155,11 +155,7 @@
     "no-underscore-dangle": 0,
     "no-unneeded-ternary": 2,
     "object-curly-spacing": [1, "always"],
-    "one-var": [1, {
-      "var"   : "always",
-      "let"   : "always",
-      "const" : "always"
-    }],
+    "one-var": 0,
     "operator-assignment": [0, "always"],
     "padded-blocks": [2, "never"],
     "quotes": [2, "single", "avoid-escape"],

--- a/build/webpack/make-config.js
+++ b/build/webpack/make-config.js
@@ -35,7 +35,8 @@ function makeDefaultConfig () {
         services    : projectConfig.inSrc('services'),
         stores      : projectConfig.inSrc('stores'),
         styles      : projectConfig.inSrc('styles'),
-        views       : projectConfig.inSrc('views')
+        views       : projectConfig.inSrc('views'),
+        utils       : projectConfig.inSrc('utils')
       }
     },
     module : {

--- a/src/constants/todo.js
+++ b/src/constants/todo.js
@@ -1,5 +1,9 @@
 /* eslint-disable */
-export const TODO_CREATE  = 'TODO_CREATE';
-export const TODO_DESTROY = 'TODO_DESTROY';
-export const TODO_TOGGLE_COMPLETE = 'TODO_TOGGLE_COMPLETE';
+import createConstants from '../utils/createConstants';
+
+export default createConstants(
+  'TODO_CREATE',
+  'TODO_DESTROY',
+  'TODO_TOGGLE_COMPLETE'
+);
 /* eslint-enable */

--- a/src/constants/todo.js
+++ b/src/constants/todo.js
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import createConstants from '../utils/createConstants';
+import createConstants from 'utils/create-constants';
 
 export default createConstants(
   'TODO_CREATE',

--- a/src/reducers/todos/index.js
+++ b/src/reducers/todos/index.js
@@ -17,24 +17,25 @@ const initialState = Immutable.List([
 ].map(createTodoItem));
 /* eslint-enable */
 
+const reducers = {
+  [TODO_CREATE]: (state, { copy }) => state.push(createTodoItem(copy)),
+  [TODO_DESTROY] : (state, { copy }) => {
+    return state.filter(todo => todo.get('copy') !== copy);
+  },
+  [TODO_TOGGLE_COMPLETE]: (state, { copy }) => {
+    return state.map(todo => {
+      return todo.get('copy') === copy
+        ? todo.set('complete', !todo.get('complete'))
+        : todo;
+    });
+  }
+};
+
 export default function todos (state = initialState, action) {
   const { type, payload } = action;
 
-  switch (type) {
-    case TODO_CREATE:
-      return state.push(
-        createTodoItem(payload.copy)
-      );
-    case TODO_DESTROY:
-      return state.filter(todo =>
-        todo.get('copy') !== payload.copy
-      );
-    case TODO_TOGGLE_COMPLETE:
-      return state.map(todo =>
-        todo.get('copy') === payload.copy ?
-          todo.set('complete', !todo.get('complete')) : todo
-      );
-    default:
-      return state;
-  }
+  const reducer = reducers[type];
+
+  if(!reducer) return state;
+  return reducer(state, payload);
 }

--- a/src/reducers/todos/index.js
+++ b/src/reducers/todos/index.js
@@ -1,5 +1,6 @@
 /* eslint-disable */
 import Immutable from 'immutable';
+import createReducer from 'utils/create-reducer';
 import {
   TODO_CREATE,
   TODO_DESTROY,
@@ -17,25 +18,16 @@ const initialState = Immutable.List([
 ].map(createTodoItem));
 /* eslint-enable */
 
-const reducers = {
-  [TODO_CREATE]: (state, { copy }) => state.push(createTodoItem(copy)),
+export default createReducer({
+  [TODO_CREATE]  : (state, { copy }) => state.push(createTodoItem(copy)),
   [TODO_DESTROY] : (state, { copy }) => {
     return state.filter(todo => todo.get('copy') !== copy);
   },
-  [TODO_TOGGLE_COMPLETE]: (state, { copy }) => {
+  [TODO_TOGGLE_COMPLETE] : (state, { copy }) => {
     return state.map(todo => {
       return todo.get('copy') === copy
         ? todo.set('complete', !todo.get('complete'))
         : todo;
     });
   }
-};
-
-export default function todos (state = initialState, action) {
-  const { type, payload } = action;
-
-  const reducer = reducers[type];
-
-  if(!reducer) return state;
-  return reducer(state, payload);
-}
+});

--- a/src/reducers/todos/index.js
+++ b/src/reducers/todos/index.js
@@ -18,7 +18,7 @@ const initialState = Immutable.List([
 ].map(createTodoItem));
 /* eslint-enable */
 
-export default createReducer({
+export default createReducer(initialState, {
   [TODO_CREATE]  : (state, { copy }) => state.push(createTodoItem(copy)),
   [TODO_DESTROY] : (state, { copy }) => {
     return state.filter(todo => todo.get('copy') !== copy);

--- a/src/utils/create-constants.js
+++ b/src/utils/create-constants.js
@@ -1,9 +1,9 @@
 import assign from 'object-assign';
 
-export default function createConstants(...constants){
+export default function createConstants (...constants) {
   return constants.reduce((acc, constant) => {
     return assign(acc, {
-      [constant]: constant
+      [constant] : constant
     });
   }, {});
 }

--- a/src/utils/create-reducer.js
+++ b/src/utils/create-reducer.js
@@ -1,0 +1,7 @@
+export default function createReducer (reducerMap) {
+  return (state, action) => {
+    const reducer = reducerMap[action.type];
+
+    return reducer ? reducer(state, action.payload) : state;
+  };
+}

--- a/src/utils/create-reducer.js
+++ b/src/utils/create-reducer.js
@@ -1,5 +1,5 @@
-export default function createReducer (reducerMap) {
-  return (state, action) => {
+export default function createReducer (initialState, reducerMap) {
+  return (state = initialState, action) => {
     const reducer = reducerMap[action.type];
 
     return reducer ? reducer(state, action.payload) : state;

--- a/src/utils/createConstants.js
+++ b/src/utils/createConstants.js
@@ -2,7 +2,7 @@ import assign from 'object-assign';
 
 export default function createConstants(...constants){
   return constants.reduce((acc, constant) => {
-    return assign(memo, {
+    return assign(acc, {
       [constant]: constant
     });
   }, {});

--- a/src/utils/createConstants.js
+++ b/src/utils/createConstants.js
@@ -1,0 +1,9 @@
+import assign from 'object-assign';
+
+export default function createConstants(...constants){
+  return constants.reduce((acc, constant) => {
+    return assign(memo, {
+      [constant]: constant
+    });
+  }, {});
+}


### PR DESCRIPTION
This PR has 2 things:

- a `createConstants` utility function. Should save some typing when building a large application
- change the switch statement in the reducer to use a reducers map, keeps the actual function clean :).

Would love to hear your thoughts!