### PR TITLE
Fix webpack client config

### DIFF
--- a/build/webpack/client/index.js
+++ b/build/webpack/client/index.js
@@ -61,5 +61,5 @@ config.module.loaders.push(
 );
 
 module.exports = function makeClientConfig (type) {
-  return require('./_' + (type || projectConfig.NODE_ENV))(config);
+  return require('./_' + (type || projectConfig.NODE_ENV).trim())(config);
 };


### PR DESCRIPTION
Hi!

The require call was failing due to an extra space so, I just added a `.trim()`... :smile: 

This is my npm script that was raising the error (I'm on Windows right now):

`"deploy": "SET NODE_ENV=production && npm run test && npm run compile"`

Thanks!
