### PR TITLE
fix(config): trim spaces from NODE_ENV to avoid problems on windows

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -1,4 +1,4 @@
-process.env.NODE_ENV = process.env.NODE_ENV || 'development';
+process.env.NODE_ENV = (process.env.NODE_ENV || 'development').trim();
 
 const resolve = require('path').resolve,
       yargs   = require('yargs').argv,


### PR DESCRIPTION
See https://github.com/davezuko/react-redux-starter-kit/pull/32.