### PR TITLE
Npm start

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Features
 Usage
 -----
 
-#### `npm run dev`
+#### `npm run dev` also `npm start`
 Runs the webpack build system just like in `compile` but enables HMR and react hot-loader. The webpack dev server can be found at `localhost:3000`.
 
 #### `npm run dev:debug`

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "clean": "rm -rf dist",
     "compile": "webpack",
+    "start": "npm run dev",
     "dev": "node --harmony ./build/webpack-dev-server",
     "dev:debug": "npm run dev -- --debug",
     "dev:debugnw": "npm run dev -- --debug --nw",


### PR DESCRIPTION
its rather convenient to install deps and then just start the app: `npm i && npm start`. What do you think?