### PR TITLE
Redux devtools 0.14.0 rc1 fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Runs the webpack build system just like in `compile` but enables HMR. The webpac
 #### `npm run dev:nw`
 Same as `npm run dev` but opens the debug tools in a new window.
 
+**Note:** you'll need to allow popups in Chrome, or you'll see an error: [issue 110](https://github.com/davezuko/react-redux-starter-kit/issues/110)
+
 #### `npm run dev:no-debug`
 Same as `npm run dev` but disables devtools.
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "react-transform-catch-errors": "^0.1.2",
     "react-transform-hmr": "^1.0.0",
     "redbox-react": "^1.0.4",
-    "redux-devtools": "^2.1.2",
+    "redux-devtools": "git+ssh://git@github.com:tomatau/redux-devtools.git",
     "sass-loader": "^2.0.0",
     "style-loader": "^0.12.1",
     "webpack": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "react-transform-catch-errors": "^0.1.2",
     "react-transform-hmr": "^1.0.0",
     "redbox-react": "^1.0.4",
-    "redux-devtools": "tomatau/redux-devtools#d77ef99126e42542c3939d09a26fd1ccb043091e",
+    "redux-devtools": "tomatau/redux-devtools#e126f799bb81a61e4a2ce69fbc501e09b15b5f5d",
     "sass-loader": "^2.0.0",
     "style-loader": "^0.12.1",
     "webpack": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "react-transform-catch-errors": "^0.1.2",
     "react-transform-hmr": "^1.0.0",
     "redbox-react": "^1.0.4",
-    "redux-devtools": "git+ssh://git@github.com:tomatau/redux-devtools.git",
+    "redux-devtools": "tomatau/redux-devtools#d77ef99126e42542c3939d09a26fd1ccb043091e",
     "sass-loader": "^2.0.0",
     "style-loader": "^0.12.1",
     "webpack": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
     "test:dev": "npm run test -- --watch",
     "deploy": "npm run test && npm run compile"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/davezuko/react-redux-starter-kit.git"
+  },
   "author": "David Zukowski <david@zuko.me> (http://zuko.me)",
   "license": "MIT",
   "dependencies": {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -27,10 +27,12 @@ export function createDevToolsWindow (store) {
   // reload in case it's reusing the same window with the old content
   win.location.reload();
 
-  win.document.write('<div id="react-devtools-root"></div>');
-
   // wait a little bit for it to reload, then render
   setTimeout(() => {
+    // Wait for the reload to prevent:
+    // "Uncaught Error: Invariant Violation: _registerComponent(...): Target container is not a DOM element."
+    win.document.write('<div id="react-devtools-root"></div>');
+
     ReactDOM.render(
       <DebugPanel top right bottom left key="debugPanel" >
         <DevTools store={store} monitor={LogMonitor} />

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import { DevTools, DebugPanel, LogMonitor } from 'redux-devtools/lib/react';
 
 export function createConstants (...constants) {
@@ -26,12 +27,14 @@ export function createDevToolsWindow (store) {
   // reload in case it's reusing the same window with the old content
   win.location.reload();
 
+  win.document.write('<div id="react-devtools-root"></div>');
+
   // wait a little bit for it to reload, then render
   setTimeout(() => {
-    React.render(
-      <DebugPanel top right bottom left >
+    ReactDOM.render(
+      <DebugPanel top right bottom left key="debugPanel" >
         <DevTools store={store} monitor={LogMonitor} />
       </DebugPanel>
-      , win.document.body);
+      , win.document.getElementById('react-devtools-root'));
   }, 10);
 }


### PR DESCRIPTION
A bit of gardening to silence some console warnings, in particular related to imports under 0.14.0-rc1:
https://github.com/gaearon/redux-devtools/issues/127

Temporarily install patched redux-devtools with the https://github.com/tomatau/redux-devtools fork until 0.14 is officially released)

Also adds a repo field to package.json