### PR TITLE
fix(webpack): do not generate source maps in production builds

### DIFF
--- a/build/webpack/_base.js
+++ b/build/webpack/_base.js
@@ -7,7 +7,6 @@ const paths = config.get('utils_paths');
 const webpackConfig = {
   name    : 'client',
   target  : 'web',
-  devtool : 'source-map',
   entry   : {
     app : [
       paths.project(config.get('dir_src'))

--- a/build/webpack/development.js
+++ b/build/webpack/development.js
@@ -1,5 +1,6 @@
 import webpackConfig from './_base';
 
+webpackConfig.devtool = 'source-map';
 webpackConfig.eslint.emitWarning = true;
 
 export default webpackConfig;


### PR DESCRIPTION
This closes #119 