### PR TITLE
Ability to add json-loader

### DIFF
--- a/build/webpack/development_hot.js
+++ b/build/webpack/development_hot.js
@@ -17,7 +17,7 @@ webpackConfig.plugins.push(
 // configuration will break other tasks such as test:unit because Webpack
 // HMR is not enabled there, and these transforms require it.
 webpackConfig.module.loaders = webpackConfig.module.loaders.map(loader => {
-  if (/js/.test(loader.test)) {
+  if (/js(?!on)/.test(loader.test)) {
     loader.query.env.development.extra['react-transform'].transforms.push({
       transform : 'react-transform-hmr',
       imports   : ['react'],


### PR DESCRIPTION
Updates react-transform HMR check to not match json-loader.

While trying to use the color-loader package, I ran into an issue with the react-transform HMR map function, matching when including the follow loader block:
```js
{
  test: /\.json$/,
  loader: 'json-loader'
}
```

Since I'm assuming it was only meant to match the babel loader.

Lastly, is there a reason you match on the test and not the loader prop?

Example: 

```js
if (/babel/.test(loader.loader)) { ... }
```
Seems to work as well?

Thanks