### PR TITLE
Better handling of `dev:nw`, we don't need to use the dock component …

### DIFF
--- a/src/containers/DevToolsWindow.js
+++ b/src/containers/DevToolsWindow.js
@@ -1,0 +1,7 @@
+import React              from 'react';
+import { createDevTools } from 'redux-devtools';
+import LogMonitor         from 'redux-devtools-log-monitor';
+
+export default createDevTools(
+  <LogMonitor />
+);

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,7 +1,7 @@
 import React        from 'react';
 import ReactDOM     from 'react-dom';
 import { Provider } from 'react-redux';
-import DevTools     from 'containers/DevTools';
+import DevTools     from 'containers/DevToolsWindow';
 
 export function createConstants (...constants) {
   return constants.reduce((acc, constant) => {
@@ -22,7 +22,7 @@ export function createDevToolsWindow (store) {
   const win = window.open(
     null,
     'redux-devtools', // give it a name so it reuses the same window
-    'menubar=no,location=no,resizable=yes,scrollbars=no,status=no'
+    `width=400,height=${window.outerHeight},menubar=no,location=no,resizable=yes,scrollbars=no,status=no`
   );
 
   // reload in case it's reusing the same window with the old content
@@ -33,6 +33,7 @@ export function createDevToolsWindow (store) {
     // Wait for the reload to prevent:
     // "Uncaught Error: Invariant Violation: _registerComponent(...): Target container is not a DOM element."
     win.document.write('<div id="react-devtools-root"></div>');
+    win.document.body.style.margin = '0';
 
     ReactDOM.render(
       <Provider store={store}>


### PR DESCRIPTION
…if we're using the new window for the dev tools.

Additionally, configure the new window to open at a more sane size.

![image](https://cloud.githubusercontent.com/assets/5489149/10801332/482f8034-7d8d-11e5-8f61-78fceeea177d.png)


Before, the utility window would try to dock the devtools to the left. So, 70% of the page would be blank. This makes it so that the utility window is filled by the `LogMonitor`, without any of the docking functionality.