### PR TITLE
fix(fe): Use ES5 syntax instead of ES6

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -1,13 +1,12 @@
 require('babel/register');
 
-const chalk     = require('chalk');
-const devServer = require('../build/webpack-dev-server');
-const config    = require('../config');
+var chalk     = require('chalk');
+var devServer = require('../build/webpack-dev-server');
+var config    = require('../config');
 
-const host = config.get('webpack_host');
-const port = config.get('webpack_port');
+var host = config.get('webpack_host');
+var port = config.get('webpack_port');
+
 devServer.listen(port, host, function () {
-  console.log(chalk.green(
-    `webpack-dev-server is now running at ${host}:${port}.`
-  ));
+  console.log(chalk.green("webpack-dev-server is now running at "+host+":"+port+"."));
 });


### PR DESCRIPTION
Dont use illegal ES6 syntax (template strings), which causes crash before start.