### PR TITLE
Use postcss-loader to plug in autoprefixer

### DIFF
--- a/build/webpack/_base.js
+++ b/build/webpack/_base.js
@@ -1,6 +1,7 @@
 import webpack           from 'webpack';
 import config            from '../../config';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
+import autoprefixer      from 'autoprefixer';
 
 const paths = config.get('utils_paths');
 
@@ -62,7 +63,7 @@ const webpackConfig = {
         loaders : [
           'style-loader',
           'css-loader',
-          'autoprefixer?browsers=last 2 version',
+          'postcss-loader',
           'sass-loader'
         ]
       },
@@ -77,7 +78,8 @@ const webpackConfig = {
   },
   sassLoader : {
     includePaths : paths.src('styles')
-  }
+  },
+  postcss : [ autoprefixer({ browsers : ['last 2 versions'] }) ]
 };
 
 // NOTE: this is a temporary workaround. I don't know how to get Karma

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   },
   "devDependencies": {
     "autoprefixer": "^6.0.3",
-    "autoprefixer-loader": "^3.1.0",
     "babel-eslint": "^4.1.1",
     "babel-loader": "^5.0.0",
     "babel-plugin-react-transform": "^1.1.0",
@@ -65,6 +64,7 @@
     "node-sass": "^3.3.3",
     "phantomjs": "^1.9.17",
     "phantomjs-polyfill": "0.0.1",
+    "postcss-loader": "^0.8.0",
     "react-addons-test-utils": "^0.14.0",
     "react-transform-catch-errors": "^1.0.0",
     "react-transform-hmr": "^1.0.0",


### PR DESCRIPTION
Accomplishes the same thing as the specialized autoprefixer-loader, but now the kit is set up for the addition/configuration of other postcss plugins, as desired.