### PR TITLE
Fixed a breakage while creating the store

### DIFF
--- a/src/store/configureStore.js
+++ b/src/store/configureStore.js
@@ -17,6 +17,8 @@ export default function configureStore (initialState, debug = false) {
       middleware,
       DevTools.instrument()
     );
+  }else{
+    createStoreWithMiddleware = compose(middleware);
   }
 
   const store = createStoreWithMiddleware(createStore)(

--- a/src/store/configureStore.js
+++ b/src/store/configureStore.js
@@ -17,7 +17,7 @@ export default function configureStore (initialState, debug = false) {
       middleware,
       DevTools.instrument()
     );
-  }else{
+  } else {
     createStoreWithMiddleware = compose(middleware);
   }
 


### PR DESCRIPTION
When debug mode is disabled by running "mpn run dev:no-debug", createStoreWithMiddleware function fails since its not initialized.