### PR TITLE
Added css-modules to css-loader

### DIFF
--- a/build/webpack/_base.js
+++ b/build/webpack/_base.js
@@ -65,7 +65,7 @@ const webpackConfig = {
         test    : /\.scss$/,
         loaders : [
           'style-loader',
-          'css-loader',
+          'css-loader?modules&importLoaders=2&localIdentName=[local]___[hash:base64:5]',
           'postcss-loader',
           'sass-loader'
         ]

--- a/src/styles/core.scss
+++ b/src/styles/core.scss
@@ -1,2 +1,2 @@
 @import 'base';
-@import 'vendor/normalize';
+:global { @import 'vendor/normalize'; }

--- a/src/views/HomeView.js
+++ b/src/views/HomeView.js
@@ -3,6 +3,7 @@ import { bindActionCreators } from 'redux';
 import { connect }            from 'react-redux';
 import counterActions         from 'actions/counter';
 import { Link }               from 'react-router';
+import styles                 from './home-view.scss';
 
 // We define mapStateToProps and mapDispatchToProps where we'd normally use
 // the @connect decorator so the data requirements are clear upfront, but then
@@ -27,7 +28,7 @@ export class HomeView extends React.Component {
       <div className='container text-center'>
         <h1>Welcome to the React Redux Starter Kit</h1>
         <h2>Sample Counter: {this.props.counter}</h2>
-        <button className='btn btn-default'
+        <button className={'btn btn-default ' + styles.btn}
                 onClick={this.props.actions.increment}>
           Increment
         </button>

--- a/src/views/home-view.scss
+++ b/src/views/home-view.scss
@@ -1,0 +1,4 @@
+.btn {
+  background-color: blue;
+  color: white;
+}


### PR DESCRIPTION
Following https://github.com/davezuko/react-redux-starter-kit/issues/204 and https://github.com/davezuko/react-redux-starter-kit/issues/195

Unsure about necessity of import-loaders, but haven't tested with @import
Added a local .btn to homeview increment button, css will show a locally scoped class.

I'm not entirely sure yet about css-modules functionality. It's not quite the same as having locally scoped css, because you need to specifically add a class from the local styles to every element you want to style. Combining this with global styles (such as bootstrap) leads to some ugly lines like `className={'btn '+styles.btn}`. This last bit can be solved by using react-css-modules, which allows for `styleName='btn'`, which is automatically resolved to the local style called `btn`, but still allows for classNames for global styles.

P.S. consider this a proof of concept. If this is something that will be added, I can make a cleaner example.