### PR TITLE
fix(karma): Avoid run tests twice when autoWatch is set to true

### DIFF
--- a/build/karma.js
+++ b/build/karma.js
@@ -4,20 +4,22 @@ import config   from '../config';
 const debug = require('debug')('kit:karma');
 debug('Create configuration.');
 
-const KARMA_ENTRY_FILE = 'karma.entry.js';
 const webpackConfig    = require('./webpack/' + config.env);
 
 const karmaConfig = {
   basePath : '../', // project root in relation to bin/karma.js
   files : [
     './node_modules/phantomjs-polyfill/bind-polyfill.js',
-    `./${config.dir_test}/**/*.js`,
-    './' + KARMA_ENTRY_FILE
+    {
+      pattern: `./${config.dir_test}/**/*.js`,
+      watched: false,
+      served: true,
+      included: true
+    }
   ],
   singleRun  : !argv.watch,
   frameworks : ['mocha', 'sinon-chai', 'chai-as-promised', 'chai'],
   preprocessors : {
-    [KARMA_ENTRY_FILE] : ['webpack'],
     [`${config.dir_test}/**/*.js`] : ['webpack']
   },
   reporters : ['spec'],

--- a/karma.entry.js
+++ b/karma.entry.js
@@ -1,3 +1,0 @@
-// Require all files in ~/src, excluding app.js
-const srcContext = require.context('./src', true, /^((?!app).)*\.(js|jsx)/);
-srcContext.keys().forEach(srcContext);


### PR DESCRIPTION
I found that the tests will run twice when file changes occurs when the Karma is set to autoWatch. For more information, please check this out: https://github.com/nikku/karma-browserify/issues/67.