### PR TITLE
docs(readme): add styles folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ The folder structure provided is only meant to serve as a guide, it is by no mea
 │   ├── reducers             # Redux reducers
 │   ├── routes               # Application route definitions
 │   ├── store                # Redux store configuration
+│   ├── styles               # Stylesheets for the application
 │   ├── utils                # Generic utilities
 │   ├── views                # Components that live at a route
 │   └── app.js               # Application bootstrap and rendering


### PR DESCRIPTION
I was copy pasting some README elements to my own app's README and figured that the `styles` folder is left out in the *structures* part.