### PR TITLE
feat(redux): add ...rest to createReducer

### DIFF
--- a/src/utils/createReducer.js
+++ b/src/utils/createReducer.js
@@ -1,9 +1,10 @@
 export function createReducer (initialState, fnMap) {
-  return (state = initialState, action) => {
+  // possible use of rest arguments: https://github.com/rackt/redux/issues/749#issuecomment-141570236
+  return (state = initialState, action, ...rest) => {
     const { type, payload } = action;
     const handler = fnMap[type];
 
-    return handler ? handler(state, payload) : state;
+    return handler ? handler(state, payload, ...rest) : state;
   };
 }
 


### PR DESCRIPTION
@Mistereo @davezuko `...rest` param bug fixed in #258

note: destructuring the `action` object in the returned function args does not work. i tried using default params with same results... assignment moved inside function body `const { type, payload } = action;`