### PR TITLE
feat(standard): add style config and refactor to match

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,4 @@
+coverage/**
 node_modules/**
+dist/**
 *.spec.js

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,8 @@
 {
   "parser"  : "babel-eslint",
   "extends" : [
-    "defaults/configurations/airbnb"
+    "standard",
+    "standard-react"
   ],
   "env"     : {
     "browser" : true
@@ -13,14 +14,6 @@
     "__DEBUG_NW__" : false
   },
   "rules": {
-    "comma-dangle" : [1, "never"],
-    "func-names"   : 0,
-    "key-spacing"  : 0,
-    "space-before-function-paren" : [2, "always"],
-    "no-else-return"   : 0,
-    "no-multi-spaces"  : 0,
-    "quotes"           : [2, "single"],
-    "jsx-quotes"       : [2, "prefer-single"],
-    "one-var"          : 0
+    "semi" : [2, "never"]
   }
 }

--- a/README.md
+++ b/README.md
@@ -5,10 +5,13 @@ React Redux Starter Kit
 [![Build Status](https://travis-ci.org/davezuko/react-redux-starter-kit.svg?branch=master)](https://travis-ci.org/davezuko/react-redux-starter-kit?branch=master)
 [![dependencies](https://david-dm.org/davezuko/react-redux-starter-kit.svg)](https://david-dm.org/davezuko/react-redux-starter-kit)
 [![devDependency Status](https://david-dm.org/davezuko/react-redux-starter-kit/dev-status.svg)](https://david-dm.org/davezuko/react-redux-starter-kit#info=devDependencies)
-
+[![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg)](http://standardjs.com/)
 
 > ### This Project Recently Upgraded to Babel 6!
 > Woohoo! If you'd like to try it out, you're welcome to build directly from the master branch. However, if troubleshooting issues with Babel isn't quite your thing, just pull the [stable v0.18.0 release](https://github.com/davezuko/react-redux-starter-kit/tree/v0.18.0) and continue on your way with Babel 5.
+
+> ### Want Semicolons?
+> After installing npm dependencies, open `.eslintrc` change the `semi` rule from `never` to `always` and then run `npm run lint:fix`. Easy as that! Or use the same npm script after installing your preferred ESLint configuration; it's easy to customize the project's code style to suit your team's needs.
 
 This starter kit is designed to get you up and running with a bunch of awesome new front-end technologies, all on top of a configurable, feature-rich webpack build system that's already setup to provide hot reloading, CSS modules with Sass support, unit testing, code coverage reports, bundle splitting, and a whole lot more.
 
@@ -66,7 +69,7 @@ Features
   * `react-transform-catch-errors` with `redbox-react` for more visible error reporting
   * Uses babel runtime rather than inline transformations
 * [ESLint](http://eslint.org)
-  * Includes [eslint-config-defaults](https://github.com/walmartlabs/eslint-config-defaults) (uses airbnb by default)
+  * Uses [Standard Style](https://github.com/feross/standard) by default, but you're welcome to change this!
   * Includes separate test-specific `.eslintrc` to work with Mocha and Chai
 
 Getting Started
@@ -100,8 +103,6 @@ Great, now that introductions have been made here's everything in full detail:
 * `npm run dev:no-debug` - Same as `npm start` but disables redux devtools.
 * `npm run test` - Runs unit tests with Karma and generates a coverage report.
 * `npm run test:dev` - Runs Karma and watches for changes to re-run tests; does not generate coverage reports.
-* `npm run lint` - Runs ESLint against your source code.
-* `npm run lint:tests` - Runs ESLint against your tests.
 * `npm run deploy`- Runs linter, tests, and then, on success, compiles your application to disk.
 
 **NOTE:** Deploying to a specific environment? Make sure to specify your target `NODE_ENV` so webpack will use the correct configuration. For example: `NODE_ENV=production npm run compile` will compile your application with `~/build/webpack/production.js`.

--- a/bin/compile.js
+++ b/bin/compile.js
@@ -1,31 +1,31 @@
-require('babel-register');
+require('babel-register')
 
-const config = require('../config');
-const debug  = require('debug')('kit:bin:compile');
+const config = require('../config')
+const debug = require('debug')('kit:bin:compile')
 
-debug('Create webpack compiler.');
+debug('Create webpack compiler.')
 
-const compiler = require('webpack')(require('../build/webpack'));
+const compiler = require('webpack')(require('../build/webpack'))
 
 compiler.run(function (err, stats) {
-  const jsonStats = stats.toJson();
+  const jsonStats = stats.toJson()
 
-  debug('Webpack compile completed.');
-  console.log(stats.toString(config.compiler_stats));
+  debug('Webpack compile completed.')
+  console.log(stats.toString(config.compiler_stats))
 
   if (err) {
-    debug('Webpack compiler encountered a fatal error.', err);
-    process.exit(1);
+    debug('Webpack compiler encountered a fatal error.', err)
+    process.exit(1)
   } else if (jsonStats.errors.length > 0) {
-    debug('Webpack compiler encountered errors.');
-    process.exit(1);
+    debug('Webpack compiler encountered errors.')
+    process.exit(1)
   } else if (jsonStats.warnings.length > 0) {
-    debug('Webpack compiler encountered warnings.');
+    debug('Webpack compiler encountered warnings.')
 
     if (config.compiler_fail_on_warning) {
-      process.exit(1);
+      process.exit(1)
     }
   } else {
-    debug('No errors / warnings encountered.');
+    debug('No errors / warnings encountered.')
   }
-});
+})

--- a/bin/karma.js
+++ b/bin/karma.js
@@ -1,3 +1,3 @@
-require('babel-register');
+require('babel-register')
 
-module.exports = require('../build/karma');
+module.exports = require('../build/karma')

--- a/bin/server.js
+++ b/bin/server.js
@@ -1,12 +1,12 @@
-require('babel-register');
+require('babel-register')
 
-const config = require('../config');
-const server = require('../server/app');
-const debug  = require('debug')('kit:bin:server');
+const config = require('../config')
+const server = require('../server/app')
+const debug = require('debug')('kit:bin:server')
 
-const host = config.server_host;
-const port = config.server_port;
+const host = config.server_host
+const port = config.server_port
 
 server.listen(port, host, function () {
-  debug('Server is now running at ' + host + ':' + port + '.');
-});
+  debug('Server is now running at ' + host + ':' + port + '.')
+})

--- a/build/karma.js
+++ b/build/karma.js
@@ -1,13 +1,13 @@
-import { argv }      from 'yargs';
-import config        from '../config';
-import webpackConfig from './webpack';
+import { argv } from 'yargs'
+import config from '../config'
+import webpackConfig from './webpack'
 
-const debug = require('debug')('kit:karma');
-debug('Create configuration.');
+const debug = require('debug')('kit:karma')
+debug('Create configuration.')
 
 const karmaConfig = {
-  basePath : '../', // project root in relation to bin/karma.js
-  files : [
+  basePath: '../', // project root in relation to bin/karma.js
+  files: [
     './node_modules/phantomjs-polyfill/bind-polyfill.js',
     {
       pattern: `./${config.dir_test}/**/*.js`,
@@ -16,38 +16,38 @@ const karmaConfig = {
       included: true
     }
   ],
-  singleRun  : !argv.watch,
-  frameworks : ['mocha', 'chai-sinon', 'chai-as-promised', 'chai'],
-  preprocessors : {
-    [`${config.dir_test}/**/*.js`] : ['webpack']
+  singleRun: !argv.watch,
+  frameworks: ['mocha', 'chai-sinon', 'chai-as-promised', 'chai'],
+  preprocessors: {
+    [`${config.dir_test}/**/*.js`]: ['webpack']
   },
-  reporters : ['spec'],
-  browsers : ['PhantomJS'],
-  webpack : {
-    devtool : 'inline-source-map',
-    resolve : webpackConfig.resolve,
-    plugins : webpackConfig.plugins
+  reporters: ['spec'],
+  browsers: ['PhantomJS'],
+  webpack: {
+    devtool: 'inline-source-map',
+    resolve: webpackConfig.resolve,
+    plugins: webpackConfig.plugins
       .filter(plugin => !plugin.__KARMA_IGNORE__),
-    module  : {
-      loaders : webpackConfig.module.loaders
+    module: {
+      loaders: webpackConfig.module.loaders
     },
-    sassLoader : webpackConfig.sassLoader
+    sassLoader: webpackConfig.sassLoader
   },
-  webpackMiddleware : {
-    noInfo : true
+  webpackMiddleware: {
+    noInfo: true
   },
-  coverageReporter : {
-    reporters : config.coverage_reporters
+  coverageReporter: {
+    reporters: config.coverage_reporters
   }
-};
-
-if (config.coverage_enabled) {
-  karmaConfig.reporters.push('coverage');
-  karmaConfig.webpack.module.preLoaders = [{
-    test    : /\.(js|jsx)$/,
-    include : new RegExp(config.dir_client),
-    loader  : 'isparta'
-  }];
 }
 
-export default (cfg) => cfg.set(karmaConfig);
+if (config.coverage_enabled) {
+  karmaConfig.reporters.push('coverage')
+  karmaConfig.webpack.module.preLoaders = [{
+    test: /\.(js|jsx)$/,
+    include: new RegExp(config.dir_client),
+    loader: 'isparta'
+  }]
+}
+
+export default (cfg) => cfg.set(karmaConfig)

--- a/build/webpack/_base.js
+++ b/build/webpack/_base.js
@@ -1,81 +1,81 @@
-import webpack           from 'webpack';
-import cssnano           from 'cssnano';
-import AddModuleExports  from 'babel-plugin-add-module-exports';
-import HtmlWebpackPlugin from 'html-webpack-plugin';
-import config            from '../../config';
+import webpack from 'webpack'
+import cssnano from 'cssnano'
+import AddModuleExports from 'babel-plugin-add-module-exports'
+import HtmlWebpackPlugin from 'html-webpack-plugin'
+import config from '../../config'
+import _debug from 'debug'
 
-const paths = config.utils_paths;
+const paths = config.utils_paths
+const debug = _debug('kit:webpack:_base')
+debug('Create configuration.')
 
-const debug = require('debug')('kit:webpack:_base');
-debug('Create configuration.');
-
-const CSS_LOADER = !config.compiler_css_modules ?
-  'css-loader?sourceMap' : [
+const CSS_LOADER = !config.compiler_css_modules
+  ? 'css-loader?sourceMap'
+  : [
     'css-loader?modules',
     'sourceMap',
     'importLoaders=1',
     'localIdentName=[name]__[local]___[hash:base64:5]'
-  ].join('&');
+  ].join('&')
 
 const webpackConfig = {
-  name    : 'client',
-  target  : 'web',
-  entry   : {
-    app : [
+  name: 'client',
+  target: 'web',
+  entry: {
+    app: [
       paths.base(config.dir_client) + '/app.js'
     ],
-    vendor : config.compiler_vendor
+    vendor: config.compiler_vendor
   },
-  output : {
-    filename   : `[name].[${config.compiler_hash_type}].js`,
-    path       : paths.base(config.dir_dist),
-    publicPath : config.compiler_public_path
+  output: {
+    filename: `[name].[${config.compiler_hash_type}].js`,
+    path: paths.base(config.dir_dist),
+    publicPath: config.compiler_public_path
   },
-  plugins : [
+  plugins: [
     AddModuleExports,
     new webpack.DefinePlugin(config.globals),
     new webpack.optimize.OccurrenceOrderPlugin(),
     new webpack.optimize.DedupePlugin(),
     new HtmlWebpackPlugin({
-      template : paths.client('index.html'),
-      hash     : false,
-      filename : 'index.html',
-      inject   : 'body',
-      minify   : {
-        collapseWhitespace : true
+      template: paths.client('index.html'),
+      hash: false,
+      filename: 'index.html',
+      inject: 'body',
+      minify: {
+        collapseWhitespace: true
       }
     })
   ],
-  resolve : {
-    root : paths.base(config.dir_client),
-    extensions : ['', '.js', '.jsx']
+  resolve: {
+    root: paths.base(config.dir_client),
+    extensions: ['', '.js', '.jsx']
   },
-  module : {
+  module: {
     preLoaders: [
       {
         test: /\.js$/,
-        loader: "eslint-loader",
+        loader: 'eslint-loader',
         exclude: /node_modules/
       }
     ],
-    loaders : [
+    loaders: [
       {
-        test    : /\.(js|jsx)$/,
-        exclude : /node_modules/,
-        loader  : 'babel',
-        query   : {
-          cacheDirectory : true,
-          plugins : ['transform-runtime'],
-          presets : ['es2015', 'react', 'stage-0'],
-          env     : {
-            development : {
-              plugins : [
+        test: /\.(js|jsx)$/,
+        exclude: /node_modules/,
+        loader: 'babel',
+        query: {
+          cacheDirectory: true,
+          plugins: ['transform-runtime'],
+          presets: ['es2015', 'react', 'stage-0'],
+          env: {
+            development: {
+              plugins: [
                 ['react-transform', {
-                  /*  omit HMR plugin by default and _only_
-                      load it in hot dev mode.  */
-                  transforms : [{
-                    transform : 'react-transform-catch-errors',
-                    imports : [ 'react', 'redbox-react']
+                  // omit HMR plugin by default and _only_ load in hot mode
+                  transforms: [{
+                    transform: 'react-transform-catch-errors',
+                    imports: ['react', 'redbox-react']
                   }]
                 }]
               ]
@@ -84,8 +84,8 @@ const webpackConfig = {
         }
       },
       {
-        test    : /\.scss$/,
-        loaders : [
+        test: /\.scss$/,
+        loaders: [
           'style-loader',
           CSS_LOADER,
           'postcss-loader',
@@ -93,8 +93,8 @@ const webpackConfig = {
         ]
       },
       {
-        test    : /\.css$/,
-        loaders : [
+        test: /\.css$/,
+        loaders: [
           'style-loader',
           CSS_LOADER
         ]
@@ -109,35 +109,35 @@ const webpackConfig = {
       /* eslint-enable */
     ]
   },
-  sassLoader : {
-    includePaths : paths.client('styles')
+  sassLoader: {
+    includePaths: paths.client('styles')
   },
-  postcss : [
+  postcss: [
     cssnano({
-      sourcemap : true,
-      autoprefixer : {
-        add      : true,
-        remove   : true,
-        browsers : ['last 2 versions']
+      sourcemap: true,
+      autoprefixer: {
+        add: true,
+        remove: true,
+        browsers: ['last 2 versions']
       },
-      discardComments : {
-        removeAll : true
+      discardComments: {
+        removeAll: true
       }
     })
   ],
   eslint: {
     configFile: `${paths.base()}/.eslintrc`
   }
-};
+}
 
 // NOTE: this is a temporary workaround. I don't know how to get Karma
 // to include the vendor bundle that webpack creates, so to get around that
 // we remove the bundle splitting when webpack is used with Karma.
 const commonChunkPlugin = new webpack.optimize.CommonsChunkPlugin({
-  names : ['vendor']
-});
-commonChunkPlugin.__KARMA_IGNORE__ = true;
+  names: ['vendor']
+})
+commonChunkPlugin.__KARMA_IGNORE__ = true
 
-webpackConfig.plugins.push(commonChunkPlugin);
+webpackConfig.plugins.push(commonChunkPlugin)
 
-export default webpackConfig;
+export default webpackConfig

--- a/build/webpack/_development.js
+++ b/build/webpack/_development.js
@@ -1,28 +1,30 @@
-import webpack from 'webpack';
-import config  from '../../config';
+/* eslint key-spacing:0 */
+import webpack from 'webpack'
+import config from '../../config'
+import _debug from 'debug'
 
-const debug = require('debug')('kit:webpack:development');
+const debug = _debug('kit:webpack:development')
 
 export default (webpackConfig) => {
-  debug('Create configuration.');
+  debug('Create configuration.')
 
-  debug('Override devtool with cheap-module-eval-source-map.');
-  webpackConfig.devtool = 'cheap-module-eval-source-map';
+  debug('Override devtool with cheap-module-eval-source-map.')
+  webpackConfig.devtool = 'cheap-module-eval-source-map'
 
   // ------------------------------------
   // Enable HMR if Configured
   // ------------------------------------
   if (config.compiler_enable_hmr) {
-    debug('Enable Hot Module Replacement (HMR).');
+    debug('Enable Hot Module Replacement (HMR).')
 
     webpackConfig.entry.app.push(
       'webpack-hot-middleware/client?path=/__webpack_hmr'
-    );
+    )
 
     webpackConfig.plugins.push(
       new webpack.HotModuleReplacementPlugin(),
       new webpack.NoErrorsPlugin()
-    );
+    )
 
     // We need to apply the react-transform HMR plugin to the Babel configuration,
     // but _only_ when HMR is enabled. Putting this in the default development
@@ -30,7 +32,7 @@ export default (webpackConfig) => {
     // HMR is not enabled there, and these transforms require it.
     webpackConfig.module.loaders = webpackConfig.module.loaders.map(loader => {
       if (/js(?!on)/.test(loader.test)) {
-        debug('Apply react-transform-hmr to babel development transforms');
+        debug('Apply react-transform-hmr to babel development transforms')
 
         const reactTransformHmr = {
           transform : 'react-transform-hmr',
@@ -41,8 +43,8 @@ export default (webpackConfig) => {
           .push(reactTransformHmr)
       }
 
-      return loader;
-    });
+      return loader
+    })
   }
 
   return webpackConfig

--- a/build/webpack/_production.js
+++ b/build/webpack/_production.js
@@ -1,44 +1,44 @@
-import webpack           from 'webpack';
-import ExtractTextPlugin from 'extract-text-webpack-plugin';
-import config            from '../../config';
+import webpack from 'webpack'
+import ExtractTextPlugin from 'extract-text-webpack-plugin'
+import config from '../../config'
+import _debug from 'debug'
 
-const debug = require('debug')('kit:webpack:production');
+const debug = _debug('kit:webpack:production')
 
 export default (webpackConfig) => {
-  debug('Create configuration.');
+  debug('Create configuration.')
 
   if (config.compiler_source_maps) {
     debug('Source maps enabled for production.')
-    webpackConfig.devtool = 'source-map';
+    webpackConfig.devtool = 'source-map'
   } else {
-    debug('Source maps are disabled in production.');
+    debug('Source maps are disabled in production.')
   }
 
-
-  debug('Apply ExtractTextPlugin to CSS loaders.');
+  debug('Apply ExtractTextPlugin to CSS loaders.')
   webpackConfig.module.loaders = webpackConfig.module.loaders.map(loader => {
     if (/css/.test(loader.test)) {
-      const [first, ...rest] = loader.loaders;
+      const [first, ...rest] = loader.loaders
 
-      loader.loader = ExtractTextPlugin.extract(first, rest.join('!'));
-      delete loader.loaders;
+      loader.loader = ExtractTextPlugin.extract(first, rest.join('!'))
+      delete loader.loaders
     }
 
-    return loader;
-  });
+    return loader
+  })
 
-  debug('Inject ExtractText and UglifyJS plugins.');
+  debug('Inject ExtractText and UglifyJS plugins.')
   webpackConfig.plugins.push(
     new ExtractTextPlugin('[name].[contenthash].css', {
-      allChunks : true
+      allChunks: true
     }),
     new webpack.optimize.UglifyJsPlugin({
-      compress : {
-        'unused' : true,
-        'dead_code' : true,
+      compress: {
+        unused: true,
+        dead_code: true
       }
     })
-  );
+  )
 
-  return webpackConfig;
+  return webpackConfig
 }

--- a/build/webpack/index.js
+++ b/build/webpack/index.js
@@ -1,4 +1,4 @@
-import config from '../../config';
-import base   from './_base'
+import config from '../../config'
+import base from './_base'
 
-export default require(`./_${config.env}`)(base);
+export default require(`./_${config.env}`)(base)

--- a/config/_base.js
+++ b/config/_base.js
@@ -1,8 +1,9 @@
-import _debug   from 'debug';
-import path     from 'path';
-import { argv } from 'yargs';
+/* eslint key-spacing:0 spaced-comment:0 */
+import _debug from 'debug'
+import path from 'path'
+import { argv } from 'yargs'
 
-const debug  = _debug('kit:config:_base');
+const debug = _debug('kit:config:_base')
 const config = {
   env : process.env.NODE_ENV,
 
@@ -53,7 +54,7 @@ const config = {
     { type : 'text-summary' },
     { type : 'html', dir : 'coverage' }
   ]
-};
+}
 
 /************************************************
 -------------------------------------------------
@@ -76,38 +77,38 @@ config.globals = {
   '__PROD__'     : config.env === 'production',
   '__DEBUG__'    : config.env === 'development' && !argv.no_debug,
   '__DEBUG_NW__' : !!argv.nw
-};
+}
 
 // ------------------------------------
 // Validate Vendor Dependencies
 // ------------------------------------
-const pkg = require('../package.json');
+const pkg = require('../package.json')
 
 config.compiler_vendor = config.compiler_vendor
   .filter(dep => {
-    if (pkg.dependencies[dep]) return true;
+    if (pkg.dependencies[dep]) return true
 
     debug(
       `Package "${dep}" was not found as an npm dependency in package.json; ` +
       `it won't be included in the webpack vendor bundle.\n` +
       `Consider removing it from vendor_dependencies in ~/config/index.js`
-    );
-  });
+    )
+  })
 
 // ------------------------------------
 // Utilities
 // ------------------------------------
 config.utils_paths = (() => {
-  const resolve  = path.resolve;
+  const resolve = path.resolve
 
   const base = (...args) =>
-    resolve.apply(resolve, [config.path_base, ...args]);
+    resolve.apply(resolve, [config.path_base, ...args])
 
   return {
     base   : base,
     client : base.bind(null, config.dir_client),
     dist   : base.bind(null, config.dir_dist)
-  };
-})();
+  }
+})()
 
-export default config;
+export default config

--- a/config/_development.js
+++ b/config/_development.js
@@ -1,10 +1,11 @@
-import { argv } from 'yargs';
+/* eslint key-spacing:0 */
+import { argv } from 'yargs'
 
 export default (config) => {
-  const HMR_ENABLED = !!argv.hot;
+  const HMR_ENABLED = !!argv.hot
   const overrides = {
     compiler_enable_hmr : HMR_ENABLED
-  };
+  }
 
   // We use an explicit public path when the assets are served by webpack
   // to fix this issue:
@@ -12,8 +13,8 @@ export default (config) => {
   if (HMR_ENABLED) {
     overrides.compiler_public_path = (
       `http://${config.server_host}:${config.server_port}/`
-    );
+    )
   }
 
-  return overrides;
-};
+  return overrides
+}

--- a/config/_production.js
+++ b/config/_production.js
@@ -1,3 +1,4 @@
+/* eslint key-spacing:0 */
 export default (config) => ({
   compiler_fail_on_warning : false,
   compiler_hash_type       : 'chunkhash',
@@ -7,4 +8,4 @@ export default (config) => ({
     chunkModules : true,
     colors : true
   }
-});
+})

--- a/config/index.js
+++ b/config/index.js
@@ -1,17 +1,17 @@
-import _debug from 'debug';
+import _debug from 'debug'
 
-const debug = _debug('kit:config');
-debug('Create configuration.');
-import base from './_base';
+const debug = _debug('kit:config')
+debug('Create configuration.')
+import base from './_base'
 
-debug(`Apply environment overrides for NODE_ENV "${base.env}".`);
-let overrides;
+debug(`Apply environment overrides for NODE_ENV "${base.env}".`)
+let overrides
 try {
-  overrides = require(`./_${base.env}`)(base);
+  overrides = require(`./_${base.env}`)(base)
 } catch (e) {
   debug(
     `No configuration overrides found for NODE_ENV "${base.env}"`
-  );
+  )
 }
 
-export default Object.assign({}, base, overrides);
+export default Object.assign({}, base, overrides)

--- a/package.json
+++ b/package.json
@@ -5,16 +5,15 @@
   "main": "index.js",
   "scripts": {
     "clean": "rm -rf dist",
-    "lint": "eslint ./src/**/*.js",
-    "lint:tests": "eslint ./tests/**/*.spec.js",
     "compile": "node -r dotenv/config --harmony bin/compile",
+    "lint:fix": "eslint **/* --fix",
     "start": "npm run dev",
     "dev": "node -r dotenv/config bin/server --hot",
     "dev:nw": "npm run dev -- --nw",
     "dev:no-debug": "npm run dev -- --no_debug",
     "test": "node -r dotenv/config ./node_modules/karma/bin/karma start bin/karma.js",
     "test:dev": "npm run test -- --watch",
-    "deploy": "npm run lint && npm run test && npm run compile"
+    "deploy": "npm run test && npm run compile"
   },
   "repository": {
     "type": "git",
@@ -52,10 +51,12 @@
     "connect-history-api-fallback": "^1.1.0",
     "css-loader": "^0.23.0",
     "eslint": "^1.10.3",
-    "eslint-config-defaults": "^7.1.1",
+    "eslint-config-standard": "^4.4.0",
+    "eslint-config-standard-react": "^1.2.1",
     "eslint-loader": "^1.1.1",
     "eslint-plugin-babel": "^3.0.0",
-    "eslint-plugin-react": "^3.3.1",
+    "eslint-plugin-react": "^3.11.3",
+    "eslint-plugin-standard": "^1.3.1",
     "express": "^4.13.3",
     "extract-text-webpack-plugin": "^0.9.0",
     "file-loader": "^0.8.4",

--- a/server/app.js
+++ b/server/app.js
@@ -1,38 +1,38 @@
-import express            from 'express';
-import historyApiFallback from 'connect-history-api-fallback';
-import config             from '../config';
+import express from 'express'
+import historyApiFallback from 'connect-history-api-fallback'
+import config from '../config'
 
-const app   = express();
-const debug = require('debug')('kit:server');
-const paths = config.utils_paths;
+const app = express()
+const debug = require('debug')('kit:server')
+const paths = config.utils_paths
 
 app.use(historyApiFallback({
-  verbose : false
-}));
+  verbose: false
+}))
 
 // Serve app with Webpack if HMR is enabled
 if (config.compiler_enable_hmr) {
-  const webpack       = require('webpack');
-  const webpackConfig = require('../build/webpack');
-  const compiler      = webpack(webpackConfig);
+  const webpack = require('webpack')
+  const webpackConfig = require('../build/webpack')
+  const compiler = webpack(webpackConfig)
 
   app.use(require('./middleware/webpack-dev')({
     compiler,
-    publicPath : webpackConfig.output.publicPath
-  }));
-  app.use(require('./middleware/webpack-hmr')({ compiler }));
+    publicPath: webpackConfig.output.publicPath
+  }))
+  app.use(require('./middleware/webpack-hmr')({ compiler }))
 } else {
   debug(
     'Application is being run outside of development mode. This starter kit ' +
     'does not provide any production-specific server functionality. To learn ' +
     'more about deployment strategies, check out the "deployment" section ' +
     'in the README.'
-  );
+  )
 
   // Serving ~/dist by default. Ideally these files should be served by
   // the web server and not the app server, but this helps to demo the
   // server in production.
-  app.use(express.static(paths.base(config.dir_dist)));
+  app.use(express.static(paths.base(config.dir_dist)))
 }
 
-export default app;
+export default app

--- a/server/middleware/webpack-dev.js
+++ b/server/middleware/webpack-dev.js
@@ -1,12 +1,13 @@
-import WebpackDevMiddleware from 'webpack-dev-middleware';
-import config               from '../../config';
+import WebpackDevMiddleware from 'webpack-dev-middleware'
+import config from '../../config'
 
-const paths = config.utils_paths;
-const debug = require('debug')('kit:server:webpack-dev');
+const paths = config.utils_paths
+const debug = require('debug')('kit:server:webpack-dev')
 
 export default function ({ compiler, publicPath }) {
-  debug('Enable Webpack dev middleware.');
+  debug('Enable Webpack dev middleware.')
 
+  /* eslint key-spacing:0 */
   return WebpackDevMiddleware(compiler, {
     publicPath,
     contentBase : paths.base(config.dir_client),
@@ -15,5 +16,5 @@ export default function ({ compiler, publicPath }) {
     noInfo      : config.compiler_quiet,
     lazy        : false,
     stats       : config.compiler_stats
-  });
+  })
 }

--- a/server/middleware/webpack-hmr.js
+++ b/server/middleware/webpack-hmr.js
@@ -1,9 +1,9 @@
-import WebpackHotMiddleware from 'webpack-hot-middleware';
+import WebpackHotMiddleware from 'webpack-hot-middleware'
 
-const debug = require('debug')('kit:server:webpack-hmr');
+const debug = require('debug')('kit:server:webpack-hmr')
 
 export default function ({ compiler }) {
-  debug('Enable Webpack Hot Module Replacement (HMR).');
+  debug('Enable Webpack Hot Module Replacement (HMR).')
 
-  return WebpackHotMiddleware(compiler);
+  return WebpackHotMiddleware(compiler)
 }

--- a/src/app.js
+++ b/src/app.js
@@ -1,26 +1,26 @@
-import React                  from 'react';
-import ReactDOM               from 'react-dom';
-import createBrowserHistory   from 'history/lib/createBrowserHistory';
-import { syncReduxAndRouter } from 'redux-simple-router';
-import routes                 from './routes';
-import Root                   from './containers/Root';
-import configureStore         from './redux/configureStore';
+import React from 'react'
+import ReactDOM from 'react-dom'
+import createBrowserHistory from 'history/lib/createBrowserHistory'
+import { syncReduxAndRouter } from 'redux-simple-router'
+import routes from './routes'
+import Root from './containers/Root'
+import configureStore from './redux/configureStore'
 
-const history = createBrowserHistory();
-const store   = configureStore(window.__INITIAL_STATE__, __DEBUG__);
+const history = createBrowserHistory()
+const store = configureStore(window.__INITIAL_STATE__, __DEBUG__)
 
-syncReduxAndRouter(history, store, (state) => state.router);
+syncReduxAndRouter(history, store, (state) => state.router)
 
 // We render the DevTools window here rather than in the Root component
 // because we need access to the store but want this logic to be removed via
 // uglification and dead code removal when __DEBUG_NW__ is false, which
 // wouldn't be possible if it was handled via a React component prop.
 if (__DEBUG__ && __DEBUG_NW__) {
-  require('utils/createDevToolsWindow').default(store);
+  require('utils/createDevToolsWindow').default(store)
 }
 
 // Render the React application to the DOM
 ReactDOM.render(
   <Root history={history} routes={routes} store={store} />,
   document.getElementById('root')
-);
+)

--- a/src/containers/DevTools.js
+++ b/src/containers/DevTools.js
@@ -1,11 +1,11 @@
-import React              from 'react';
-import { createDevTools } from 'redux-devtools';
-import LogMonitor         from 'redux-devtools-log-monitor';
-import DockMonitor        from 'redux-devtools-dock-monitor';
+import React from 'react'
+import { createDevTools } from 'redux-devtools'
+import LogMonitor from 'redux-devtools-log-monitor'
+import DockMonitor from 'redux-devtools-dock-monitor'
 
 export default createDevTools(
   <DockMonitor toggleVisibilityKey='H'
                changePositionKey='Q'>
     <LogMonitor />
   </DockMonitor>
-);
+)

--- a/src/containers/DevToolsWindow.js
+++ b/src/containers/DevToolsWindow.js
@@ -1,7 +1,7 @@
-import React              from 'react';
-import { createDevTools } from 'redux-devtools';
-import LogMonitor         from 'redux-devtools-log-monitor';
+import React from 'react'
+import { createDevTools } from 'redux-devtools'
+import LogMonitor from 'redux-devtools-log-monitor'
 
 export default createDevTools(
   <LogMonitor />
-);
+)

--- a/src/containers/Root.js
+++ b/src/containers/Root.js
@@ -1,12 +1,12 @@
-import React        from 'react';
-import { Provider } from 'react-redux';
-import { Router }   from 'react-router';
+import React from 'react'
+import { Provider } from 'react-redux'
+import { Router } from 'react-router'
 
 export default class Root extends React.Component {
   static propTypes = {
-    history : React.PropTypes.object.isRequired,
-    routes  : React.PropTypes.element.isRequired,
-    store   : React.PropTypes.object.isRequired
+    history: React.PropTypes.object.isRequired,
+    routes: React.PropTypes.element.isRequired,
+    store: React.PropTypes.object.isRequired
   }
 
   render () {
@@ -14,10 +14,10 @@ export default class Root extends React.Component {
       <Router history={this.props.history}>
         {this.props.routes}
       </Router>
-    );
+    )
 
     if (__DEBUG__ && !__DEBUG_NW__) {
-      const DevTools = require('containers/DevTools').default;
+      const DevTools = require('containers/DevTools').default
 
       return (
         <Provider store={this.props.store}>
@@ -26,13 +26,13 @@ export default class Root extends React.Component {
             <DevTools />
           </div>
         </Provider>
-      );
+      )
     } else {
       return (
         <Provider store={this.props.store}>
           {content}
         </Provider>
-      );
+      )
     }
   }
 }

--- a/src/layouts/CoreLayout.js
+++ b/src/layouts/CoreLayout.js
@@ -1,9 +1,9 @@
-import React from 'react';
-import 'styles/core.scss';
+import React from 'react'
+import 'styles/core.scss'
 
 export default class CoreLayout extends React.Component {
   static propTypes = {
-    children : React.PropTypes.element
+    children: React.PropTypes.element
   }
 
   render () {
@@ -13,6 +13,6 @@ export default class CoreLayout extends React.Component {
           {this.props.children}
         </div>
       </div>
-    );
+    )
   }
 }

--- a/src/redux/configureStore.js
+++ b/src/redux/configureStore.js
@@ -1,34 +1,34 @@
-import thunk       from 'redux-thunk';
-import rootReducer from './modules';
+import thunk from 'redux-thunk'
+import rootReducer from './modules'
 import {
   applyMiddleware,
   compose,
   createStore
-} from 'redux';
+} from 'redux'
 
 export default function configureStore (initialState) {
-  let createStoreWithMiddleware;
+  let createStoreWithMiddleware
 
-  const middleware = applyMiddleware(thunk);
+  const middleware = applyMiddleware(thunk)
 
   if (__DEBUG__) {
     createStoreWithMiddleware = compose(
       middleware,
       require('containers/DevTools').default.instrument()
-    );
+    )
   } else {
-    createStoreWithMiddleware = compose(middleware);
+    createStoreWithMiddleware = compose(middleware)
   }
 
   const store = createStoreWithMiddleware(createStore)(
     rootReducer, initialState
-  );
+  )
   if (module.hot) {
     module.hot.accept('./modules', () => {
-      const nextRootReducer = require('./modules').default;
+      const nextRootReducer = require('./modules').default
 
-      store.replaceReducer(nextRootReducer);
-    });
+      store.replaceReducer(nextRootReducer)
+    })
   }
-  return store;
+  return store
 }

--- a/src/redux/modules/counter.js
+++ b/src/redux/modules/counter.js
@@ -1,21 +1,21 @@
-import createReducer from 'utils/createReducer';
+import createReducer from 'utils/createReducer'
 
 // ------------------------------------
 // Constants
 // ------------------------------------
-const COUNTER_INCREMENT = 'COUNTER_INCREMENT';
+const COUNTER_INCREMENT = 'COUNTER_INCREMENT'
 
 // ------------------------------------
 // Actions
 // ------------------------------------
-export const increment = () => ({ type : COUNTER_INCREMENT });
+export const increment = () => ({ type: COUNTER_INCREMENT })
 export const actions = {
   increment
-};
+}
 
 // ------------------------------------
 // Reducer
 // ------------------------------------
 export default createReducer(0, {
-  [COUNTER_INCREMENT] : (state) => state + 1
-});
+  [COUNTER_INCREMENT]: (state) => state + 1
+})

--- a/src/redux/modules/index.js
+++ b/src/redux/modules/index.js
@@ -1,8 +1,8 @@
-import { combineReducers } from 'redux';
-import { routeReducer }    from 'redux-simple-router';
-import counter             from './counter';
+import { combineReducers } from 'redux'
+import { routeReducer } from 'redux-simple-router'
+import counter from './counter'
 
 export default combineReducers({
   counter,
-  router : routeReducer
-});
+  router: routeReducer
+})

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,12 +1,12 @@
-import React                 from 'react';
-import { Route, IndexRoute } from 'react-router';
-import CoreLayout            from 'layouts/CoreLayout';
-import HomeView              from 'views/HomeView';
-import AboutView             from 'views/AboutView';
+import React from 'react'
+import { Route, IndexRoute } from 'react-router'
+import CoreLayout from 'layouts/CoreLayout'
+import HomeView from 'views/HomeView'
+import AboutView from 'views/AboutView'
 
 export default (
-  <Route        component={CoreLayout} path='/'>
+  <Route component={CoreLayout} path='/'>
     <IndexRoute component={HomeView} />
-    <Route      component={AboutView}  path='/about' />
+    <Route component={AboutView} path='/about' />
   </Route>
-);
+)

--- a/src/utils/createDevToolsWindow.js
+++ b/src/utils/createDevToolsWindow.js
@@ -1,30 +1,30 @@
-import React        from 'react';
-import ReactDOM     from 'react-dom';
-import { Provider } from 'react-redux';
-import DevTools     from 'containers/DevToolsWindow';
+import React from 'react'
+import ReactDOM from 'react-dom'
+import { Provider } from 'react-redux'
+import DevTools from 'containers/DevToolsWindow'
 
 export default function createDevToolsWindow (store) {
   const win = window.open(
     null,
     'redux-devtools', // give it a name so it reuses the same window
     `width=400,height=${window.outerHeight},menubar=no,location=no,resizable=yes,scrollbars=no,status=no`
-  );
+  )
 
   // reload in case it's reusing the same window with the old content
-  win.location.reload();
+  win.location.reload()
 
   // wait a little bit for it to reload, then render
   setTimeout(() => {
     // Wait for the reload to prevent:
     // "Uncaught Error: Invariant Violation: _registerComponent(...): Target container is not a DOM element."
-    win.document.write('<div id="react-devtools-root"></div>');
-    win.document.body.style.margin = '0';
+    win.document.write('<div id="react-devtools-root"></div>')
+    win.document.body.style.margin = '0'
 
     ReactDOM.render(
       <Provider store={store}>
         <DevTools />
       </Provider>
       , win.document.getElementById('react-devtools-root')
-    );
-  }, 10);
+    )
+  }, 10)
 }

--- a/src/utils/createReducer.js
+++ b/src/utils/createReducer.js
@@ -1,11 +1,11 @@
 export function createReducer (initialState, fnMap) {
   // possible use of rest arguments: https://github.com/rackt/redux/issues/749#issuecomment-141570236
   return (state = initialState, action, ...rest) => {
-    const { type, payload } = action;
-    const handler = fnMap[type];
+    const { type, payload } = action
+    const handler = fnMap[type]
 
-    return handler ? handler(state, payload, ...rest) : state;
-  };
+    return handler ? handler(state, payload, ...rest) : state
+  }
 }
 
-export default createReducer;
+export default createReducer

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,2 +1,2 @@
-export createReducer        from './createReducer.js';
-export createDevToolsWindow from './createDevToolsWindow.js';
+export createReducer from './createReducer.js'
+export createDevToolsWindow from './createDevToolsWindow.js'

--- a/src/views/AboutView.js
+++ b/src/views/AboutView.js
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Link } from 'react-router';
+import React from 'react'
+import { Link } from 'react-router'
 
 const AboutView = () => (
   <div className='container text-center'>
@@ -7,6 +7,6 @@ const AboutView = () => (
     <hr />
     <Link to='/'>Back To Home View</Link>
   </div>
-);
+)
 
-export default AboutView;
+export default AboutView

--- a/src/views/HomeView.js
+++ b/src/views/HomeView.js
@@ -1,8 +1,8 @@
-import React from 'react';
-import { connect } from 'react-redux';
-import { Link } from 'react-router';
-import { actions as counterActions } from '../redux/modules/counter';
-import styles from './HomeView.scss';
+import React from 'react'
+import { connect } from 'react-redux'
+import { Link } from 'react-router'
+import { actions as counterActions } from '../redux/modules/counter'
+import styles from './HomeView.scss'
 
 // We define mapStateToProps where we'd normally use
 // the @connect decorator so the data requirements are clear upfront, but then
@@ -10,12 +10,12 @@ import styles from './HomeView.scss';
 // the component can be tested w/ and w/o being connected.
 // See: http://rackt.github.io/redux/docs/recipes/WritingTests.html
 const mapStateToProps = (state) => ({
-  counter : state.counter
-});
+  counter: state.counter
+})
 export class HomeView extends React.Component {
   static propTypes = {
-    increment : React.PropTypes.func,
-    counter   : React.PropTypes.number
+    increment: React.PropTypes.func,
+    counter: React.PropTypes.number
   }
 
   render () {
@@ -33,8 +33,8 @@ export class HomeView extends React.Component {
         <hr />
         <Link to='/about'>Go To About View</Link>
       </div>
-    );
+    )
   }
 }
 
-export default connect(mapStateToProps, counterActions)(HomeView);
+export default connect(mapStateToProps, counterActions)(HomeView)

--- a/tests/.eslintrc
+++ b/tests/.eslintrc
@@ -1,14 +1,11 @@
 {
   "extends" : "../.eslintrc",
   "env"     : {
-    "mocha"   : true
+    "mocha" : true
   },
   "globals" : {
     "expect" : false,
+    "should" : false,
     "sinon"  : false
-  },
-  "rules": {
-    "func-names" : 0,
-    "no-unused-expressions" : 0
   }
 }

--- a/tests/framework.spec.js
+++ b/tests/framework.spec.js
@@ -1,21 +1,21 @@
-import assert from 'assert';
+import assert from 'assert'
 
 describe('(Framework) Karma Plugins', function () {
   it('Should expose "expect" globally.', function () {
-    assert.ok(expect);
-  });
+    assert.ok(expect)
+  })
 
   it('Should expose "should" globally.', function () {
-    assert.ok(should);
-  });
+    assert.ok(should)
+  })
 
   it('Should have chai-as-promised helpers.', function () {
-    const pass = new Promise(res => res('test'));
-    const fail = new Promise((res, rej) => rej());
+    const pass = new Promise(res => res('test'))
+    const fail = new Promise((res, rej) => rej())
 
     return Promise.all([
       expect(pass).to.be.fulfilled,
       expect(fail).to.not.be.fulfilled
-    ]);
-  });
-});
+    ])
+  })
+})

--- a/tests/layouts/CoreLayout.spec.js
+++ b/tests/layouts/CoreLayout.spec.js
@@ -1,44 +1,44 @@
-import React      from 'react';
-import TestUtils  from 'react-addons-test-utils';
-import CoreLayout from 'layouts/CoreLayout';
+import React from 'react'
+import TestUtils from 'react-addons-test-utils'
+import CoreLayout from 'layouts/CoreLayout'
 
 function shallowRender (component) {
-  const renderer = TestUtils.createRenderer();
+  const renderer = TestUtils.createRenderer()
 
-  renderer.render(component);
-  return renderer.getRenderOutput();
+  renderer.render(component)
+  return renderer.getRenderOutput()
 }
 
 function renderWithProps (props = {}) {
-  return TestUtils.renderIntoDocument(<CoreLayout {...props} />);
+  return TestUtils.renderIntoDocument(<CoreLayout {...props} />)
 }
 
 function shallowRenderWithProps (props = {}) {
-  return shallowRender(<CoreLayout {...props} />);
+  return shallowRender(<CoreLayout {...props} />)
 }
 
 describe('(Layout) Core', function () {
-  let _component, _rendered, _props, _child;
+  let _component, _rendered, _props, _child
 
   beforeEach(function () {
-    _child = <h1 className='child'>Child</h1>;
+    _child = <h1 className='child'>Child</h1>
     _props = {
-      children : _child
-    };
+      children: _child
+    }
 
-    _component = shallowRenderWithProps(_props);
-    _rendered  = renderWithProps(_props);
-  });
+    _component = shallowRenderWithProps(_props)
+    _rendered = renderWithProps(_props)
+  })
 
   it('Should render as a <div>.', function () {
-    expect(_component.type).to.equal('div');
-  });
+    expect(_component.type).to.equal('div')
+  })
 
   it('Should render a child component.', function () {
     const child = TestUtils.findRenderedDOMComponentWithClass(
       _rendered, 'child'
-    );
+    )
 
-    expect(child).to.exist;
-  });
-});
+    expect(child).to.exist
+  })
+})

--- a/tests/views/HomeView.spec.js
+++ b/tests/views/HomeView.spec.js
@@ -1,76 +1,75 @@
-import React                  from 'react';
-import TestUtils              from 'react-addons-test-utils';
-import { bindActionCreators } from 'redux';
-import { HomeView }           from 'views/HomeView';
+import React from 'react'
+import TestUtils from 'react-addons-test-utils'
+import { bindActionCreators } from 'redux'
+import { HomeView } from 'views/HomeView'
 
 function shallowRender (component) {
-  const renderer = TestUtils.createRenderer();
+  const renderer = TestUtils.createRenderer()
 
-  renderer.render(component);
-  return renderer.getRenderOutput();
+  renderer.render(component)
+  return renderer.getRenderOutput()
 }
 
 function renderWithProps (props = {}) {
-  return TestUtils.renderIntoDocument(<HomeView {...props} />);
+  return TestUtils.renderIntoDocument(<HomeView {...props} />)
 }
 
 function shallowRenderWithProps (props = {}) {
-  return shallowRender(<HomeView {...props} />);
+  return shallowRender(<HomeView {...props} />)
 }
 
 describe('(View) Home', function () {
-  let _component, _rendered, _props, _spies;
+  let _component, _rendered, _props, _spies
 
   beforeEach(function () {
-    _spies = {};
+    _spies = {}
     _props = bindActionCreators({
-      increment : (_spies.increment = sinon.spy())
+      increment: (_spies.increment = sinon.spy())
     }, _spies.dispatch = sinon.spy())
 
-
-    _component = shallowRenderWithProps(_props);
-    _rendered  = renderWithProps(_props);
-  });
+    _component = shallowRenderWithProps(_props)
+    _rendered = renderWithProps(_props)
+  })
 
   it('Should render as a <div>.', function () {
-    expect(_component.type).to.equal('div');
-  });
+    expect(_component.type).to.equal('div')
+  })
 
   it('Should include an <h1> with welcome text.', function () {
-    const h1 = TestUtils.findRenderedDOMComponentWithTag(_rendered, 'h1');
+    const h1 = TestUtils.findRenderedDOMComponentWithTag(_rendered, 'h1')
 
-    expect(h1).to.exist;
-    expect(h1.textContent).to.match(/Welcome to the React Redux Starter Kit/);
-  });
+    expect(h1).to.exist
+    expect(h1.textContent).to.match(/Welcome to the React Redux Starter Kit/)
+  })
 
   it('Should render with an <h2> that includes Sample Counter text.', function () {
-    const h2 = TestUtils.findRenderedDOMComponentWithTag(_rendered, 'h2');
+    const h2 = TestUtils.findRenderedDOMComponentWithTag(_rendered, 'h2')
 
-    expect(h2).to.exist;
-    expect(h2.textContent).to.match(/Sample Counter/);
-  });
+    expect(h2).to.exist
+    expect(h2.textContent).to.match(/Sample Counter/)
+  })
 
   it('Should render props.counter at the end of the sample counter <h2>.', function () {
     const h2 = TestUtils.findRenderedDOMComponentWithTag(
-      renderWithProps({ ..._props, counter : 5 }), 'h2'
-    );
+      renderWithProps({ ..._props, counter: 5 }), 'h2'
+    )
 
-    expect(h2).to.exist;
-    expect(h2.textContent).to.match(/5$/);
-  });
+    expect(h2).to.exist
+    expect(h2.textContent).to.match(/5$/)
+  })
 
   it('Should render an "Increment" button.', function () {
-    const btn = TestUtils.findRenderedDOMComponentWithTag(_rendered, 'button');
+    const btn = TestUtils.findRenderedDOMComponentWithTag(_rendered, 'button')
 
-    expect(btn).to.exist;
-    expect(btn.textContent).to.match(/Increment/);
-  });
+    expect(btn).to.exist
+    expect(btn.textContent).to.match(/Increment/)
+  })
 
   it('Should dispatch an action when "Increment" button is clicked.', function () {
-    const btn = TestUtils.findRenderedDOMComponentWithTag(_rendered, 'button');
+    const btn = TestUtils.findRenderedDOMComponentWithTag(_rendered, 'button')
 
-    _spies.dispatch.should.have.not.been.called;
-    TestUtils.Simulate.click(btn);
-    _spies.dispatch.should.have.been.called;
-  });
-});
+    _spies.dispatch.should.have.not.been.called
+    TestUtils.Simulate.click(btn)
+    _spies.dispatch.should.have.been.called
+  })
+})


### PR DESCRIPTION
@justingreenberg @mtsr thoughts?

@justingreenberg I found out that standard-style is actually fairly close to what I had, save for my obsessive import and colon alignment (which should be dropped anyways to improve git diffs). Also, standard style enforces `function () {` instead of the `function() {` from rackt -- which I will fight to the death.

I know it's a big change, and it may alienate some people, but that's why I'm not just merging my own PR :).