### PR TITLE
fix(babel): fix export interop, remove hotfix

### DIFF
--- a/build/webpack/_base.js
+++ b/build/webpack/_base.js
@@ -1,6 +1,5 @@
 import webpack from 'webpack'
 import cssnano from 'cssnano'
-import AddModuleExports from 'babel-plugin-add-module-exports'
 import HtmlWebpackPlugin from 'html-webpack-plugin'
 import config from '../../config'
 import _debug from 'debug'
@@ -33,7 +32,6 @@ const webpackConfig = {
     publicPath: config.compiler_public_path
   },
   plugins: [
-    AddModuleExports,
     new webpack.DefinePlugin(config.globals),
     new webpack.optimize.OccurrenceOrderPlugin(),
     new webpack.optimize.DedupePlugin(),
@@ -66,7 +64,7 @@ const webpackConfig = {
         loader: 'babel',
         query: {
           cacheDirectory: true,
-          plugins: ['transform-runtime'],
+          plugins: ['transform-runtime', 'add-module-exports'],
           presets: ['es2015', 'react', 'stage-0'],
           env: {
             development: {

--- a/src/app.js
+++ b/src/app.js
@@ -16,7 +16,7 @@ syncReduxAndRouter(history, store, (state) => state.router)
 // uglification and dead code removal when __DEBUG_NW__ is false, which
 // wouldn't be possible if it was handled via a React component prop.
 if (__DEBUG__ && __DEBUG_NW__) {
-  require('utils/createDevToolsWindow').default(store)
+  require('utils/createDevToolsWindow')(store)
 }
 
 // Render the React application to the DOM

--- a/src/containers/Root.js
+++ b/src/containers/Root.js
@@ -17,7 +17,7 @@ export default class Root extends React.Component {
     )
 
     if (__DEBUG__ && !__DEBUG_NW__) {
-      const DevTools = require('containers/DevTools').default
+      const DevTools = require('containers/DevTools')
 
       return (
         <Provider store={this.props.store}>

--- a/src/redux/configureStore.js
+++ b/src/redux/configureStore.js
@@ -14,7 +14,7 @@ export default function configureStore (initialState) {
   if (__DEBUG__) {
     createStoreWithMiddleware = compose(
       middleware,
-      require('containers/DevTools').default.instrument()
+      require('containers/DevTools').instrument()
     )
   } else {
     createStoreWithMiddleware = compose(middleware)
@@ -25,7 +25,7 @@ export default function configureStore (initialState) {
   )
   if (module.hot) {
     module.hot.accept('./modules', () => {
-      const nextRootReducer = require('./modules').default
+      const nextRootReducer = require('./modules')
 
       store.replaceReducer(nextRootReducer)
     })


### PR DESCRIPTION
i'm not sure when or how the plugin broke but this fixes es6 default export interop with commonjs and removes the `{ default }` hotfix for inline require statements 