### PR TITLE
fix(webpack): run .css files through postcss-loader

### DIFF
--- a/build/webpack/_base.js
+++ b/build/webpack/_base.js
@@ -94,7 +94,8 @@ const webpackConfig = {
         test: /\.css$/,
         loaders: [
           'style-loader',
-          CSS_LOADER
+          CSS_LOADER,
+          'postcss-loader'
         ]
       },
       /* eslint-disable */


### PR DESCRIPTION
Fixes https://github.com/davezuko/react-redux-starter-kit/issues/282