### PR TITLE
fix(app): fix root element style so that height 100% applies

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -7,6 +7,6 @@
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">
 </head>
 <body>
-  <div id="root" class="root"></div>
+  <div id="root" style="height: 100%"></div>
 </body>
 </html>

--- a/src/styles/_base.scss
+++ b/src/styles/_base.scss
@@ -17,8 +17,4 @@ body {
   box-sizing: inherit;
 }
 
-.root {
-  height: 100%;
-}
-
 // Additional settings go here


### PR DESCRIPTION
For some reason, the root class didn't "take" and the style approach feels cleaner since it's out of the way.