### PR TITLE
feat(server): Static Assets

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -28,11 +28,8 @@ if (config.compiler_enable_hmr) {
     'more about deployment strategies, check out the "deployment" section ' +
     'in the README.'
   )
-
-  // Serving ~/dist by default. Ideally these files should be served by
-  // the web server and not the app server, but this helps to demo the
-  // server in production.
-  app.use(express.static(paths.base(config.dir_dist)))
 }
+
+app.use(express.static(paths.base('static')))
 
 export default app

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow:


### PR DESCRIPTION
I removed comments as express can be run as your web server, and in the development mode it already is doing that. It might be worthwhile to remove the debug() production notice as well as this could be a universal starter kit. 