### PR TITLE
fix(counter): use constant rather than string for action handler

### DIFF
--- a/src/redux/modules/counter.js
+++ b/src/redux/modules/counter.js
@@ -33,5 +33,5 @@ export const actions = {
 // Reducer
 // ------------------------------------
 export default handleActions({
-  COUNTER_INCREMENT: (state, { payload }) => state + payload
+  [COUNTER_INCREMENT]: (state, { payload }) => state + payload
 }, 1)


### PR DESCRIPTION
Resolves https://github.com/davezuko/react-redux-starter-kit/issues/322