### PR TITLE
refactor(imports): always use relative paths except in routes

### DIFF
--- a/src/layouts/CoreLayout.js
+++ b/src/layouts/CoreLayout.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import 'styles/core.scss'
+import '../styles/core.scss'
 
 // Note: Stateless/function components *will not* hot reload!
 // react-transform *only* works on component classes.

--- a/src/redux/utils/createDevToolsWindow.js
+++ b/src/redux/utils/createDevToolsWindow.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import { Provider } from 'react-redux'
-import DevTools from 'containers/DevToolsWindow'
+import DevTools from '../../containers/DevToolsWindow'
 
 export default function createDevToolsWindow (store) {
   const win = window.open(

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,5 +1,11 @@
 import React from 'react'
 import { Route, IndexRoute } from 'react-router'
+
+// NOTE: here we're making use of the `resolve.root` configuration
+// option in webpack, which allows us to specify import paths as if
+// they were from the root of the ~/src directory. This makes it
+// very easy to navigate to files regardless of how deeply nested
+// your current file is.
 import CoreLayout from 'layouts/CoreLayout'
 import HomeView from 'views/HomeView'
 import AboutView from 'views/AboutView'


### PR DESCRIPTION
resolves https://github.com/davezuko/react-redux-starter-kit/issues/307