### PR TITLE
chore(webpack): use ProvidePlugin to reduce boilerplate

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,9 +11,12 @@
     "__DEV__"      : false,
     "__PROD__"     : false,
     "__DEBUG__"    : false,
-    "__DEBUG_NEW_WINDOW__" : false
+    "__DEBUG_NEW_WINDOW__" : false,
+    "React": true,
+    "ReactDOM": true
   },
   "rules": {
-    "semi" : [2, "never"]
+    "semi" : [2, "never"],
+    "react-in-jsx-scope": 0
   }
 }

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ These are global variables available to you anywhere in your source code. If you
 ### Provided Plugins
 
 Webpack is configured to use [ProvidePlugin](https://webpack.github.io/docs/list-of-plugins.html#provideplugin), which lets you use commonly used imports
-without explicitly writing an import statement, reducing boilerplate. To add more automatic imports, add them to `providedPlugins` in `~/build/webpack-environments/_base.js`. Additionally, add them to your `.eslintrc` file as a global as webpack will import them if encountered.
+without explicitly writing an import statement, reducing boilerplate. To add more automatic imports, add them to `config_globals` in `~/config/_base`. Additionally, add them to the globals object in your `.eslintrc` file as webpack will import them if encountered.
 
 Server
 ------

--- a/README.md
+++ b/README.md
@@ -200,6 +200,11 @@ These are global variables available to you anywhere in your source code. If you
 * `__DEV__` - True when `process.env.NODE_ENV` is `development`
 * `__PROD__` - True when `process.env.NODE_ENV` is `production`
 
+### Provided Plugins
+
+Webpack is configured to use [ProvidePlugin](https://webpack.github.io/docs/list-of-plugins.html#provideplugin), which lets you use commonly used imports
+without explicitly writing an import statement, reducing boilerplate. To add more automatic imports, add them to `providedPlugins` in `~/build/webpack-environments/_base.js`. Additionally, add them to your `.eslintrc` file as a global as webpack will import them if encountered.
+
 Server
 ------
 

--- a/build/webpack-environments/_base.js
+++ b/build/webpack-environments/_base.js
@@ -17,6 +17,11 @@ const CSS_LOADER = !config.compiler_css_modules
     'localIdentName=[name]__[local]___[hash:base64:5]'
   ].join('&')
 
+const providedPlugins = {
+  'React': 'react',
+  'ReactDOM': 'react-dom'
+}
+
 const webpackConfig = {
   name: 'client',
   target: 'web',
@@ -44,7 +49,8 @@ const webpackConfig = {
       minify: {
         collapseWhitespace: true
       }
-    })
+    }),
+    new webpack.ProvidePlugin(providedPlugins)
   ],
   resolve: {
     root: paths.base(config.dir_client),

--- a/build/webpack-environments/_base.js
+++ b/build/webpack-environments/_base.js
@@ -17,11 +17,6 @@ const CSS_LOADER = !config.compiler_css_modules
     'localIdentName=[name]__[local]___[hash:base64:5]'
   ].join('&')
 
-const providedPlugins = {
-  'React': 'react',
-  'ReactDOM': 'react-dom'
-}
-
 const webpackConfig = {
   name: 'client',
   target: 'web',
@@ -50,7 +45,7 @@ const webpackConfig = {
         collapseWhitespace: true
       }
     }),
-    new webpack.ProvidePlugin(providedPlugins)
+    new webpack.ProvidePlugin(config.compiler_globals)
   ],
   resolve: {
     root: paths.base(config.dir_client),

--- a/config/_base.js
+++ b/config/_base.js
@@ -27,6 +27,10 @@ const config = {
   // ----------------------------------
   compiler_css_modules     : true,
   compiler_enable_hmr      : false,
+  compiler_globals         : {
+    'React' : 'react',
+    'ReactDOM' : 'react-dom'
+  },
   compiler_source_maps     : true,
   compiler_hash_type       : 'hash',
   compiler_fail_on_warning : false,

--- a/src/containers/DevTools.js
+++ b/src/containers/DevTools.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { createDevTools } from 'redux-devtools'
 import LogMonitor from 'redux-devtools-log-monitor'
 import DockMonitor from 'redux-devtools-dock-monitor'

--- a/src/containers/DevToolsWindow.js
+++ b/src/containers/DevToolsWindow.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { createDevTools } from 'redux-devtools'
 import LogMonitor from 'redux-devtools-log-monitor'
 

--- a/src/containers/Root.js
+++ b/src/containers/Root.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Provider } from 'react-redux'
 import { Router } from 'react-router'
 

--- a/src/layouts/CoreLayout.js
+++ b/src/layouts/CoreLayout.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import '../styles/core.scss'
 
 // Note: Stateless/function components *will not* hot reload!

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,3 @@
-import React from 'react'
-import ReactDOM from 'react-dom'
 import createBrowserHistory from 'history/lib/createBrowserHistory'
 import { syncReduxAndRouter } from 'redux-simple-router'
 import routes from './routes'

--- a/src/redux/utils/createDevToolsWindow.js
+++ b/src/redux/utils/createDevToolsWindow.js
@@ -1,5 +1,3 @@
-import React from 'react'
-import ReactDOM from 'react-dom'
 import { Provider } from 'react-redux'
 import DevTools from '../../containers/DevToolsWindow'
 

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Route, IndexRoute } from 'react-router'
 
 // NOTE: here we're making use of the `resolve.root` configuration

--- a/src/views/AboutView.js
+++ b/src/views/AboutView.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Link } from 'react-router'
 
 export class AboutView extends React.Component {

--- a/src/views/HomeView.js
+++ b/src/views/HomeView.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { connect } from 'react-redux'
 import { Link } from 'react-router'
 import { actions as counterActions } from '../redux/modules/counter'

--- a/tests/layouts/CoreLayout.spec.js
+++ b/tests/layouts/CoreLayout.spec.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import TestUtils from 'react-addons-test-utils'
 import CoreLayout from 'layouts/CoreLayout'
 

--- a/tests/views/HomeView.spec.js
+++ b/tests/views/HomeView.spec.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import TestUtils from 'react-addons-test-utils'
 import { bindActionCreators } from 'redux'
 import { HomeView } from 'views/HomeView'


### PR DESCRIPTION
I really appreciate the effort that has gone into this project! It's been my goto to test new ideas and build a few projects.

Submitting this PR for review to reduce boilerplate. It uses webpack's ProvidePlugin to implicitly import React and ReactDom.

It also turns the `react-in-jsx-scope` rule off and makes React and ReactDOM globals.
