### PR TITLE
feat(devtools): Use redux-devtools-extension if available

### DIFF
--- a/src/containers/Root.js
+++ b/src/containers/Root.js
@@ -18,7 +18,7 @@ export default class Root extends React.Component {
   }
 
   get devTools () {
-    if (__DEBUG__) {
+    if (__DEBUG__ && !window.devToolsExtension) {
       if (__DEBUG_NEW_WINDOW__) {
         require('../redux/utils/createDevToolsWindow')(this.props.store)
       } else {

--- a/src/containers/Root.js
+++ b/src/containers/Root.js
@@ -18,10 +18,14 @@ export default class Root extends React.Component {
   }
 
   get devTools () {
-    if (__DEBUG__ && !window.devToolsExtension) {
+    if (__DEBUG__) {
       if (__DEBUG_NEW_WINDOW__) {
-        require('../redux/utils/createDevToolsWindow')(this.props.store)
-      } else {
+        if (!window.devToolsExtension) {
+          require('../redux/utils/createDevToolsWindow')(this.props.store)
+        } else {
+          window.devToolsExtension.open()
+        }
+      } else if (!window.devToolsExtension) {
         const DevTools = require('containers/DevTools')
         return <DevTools />
       }

--- a/src/redux/configureStore.js
+++ b/src/redux/configureStore.js
@@ -14,7 +14,7 @@ export default function configureStore (initialState) {
   if (__DEBUG__) {
     createStoreWithMiddleware = compose(
       middleware,
-      window.devToolsExtension() ? window.devToolsExtension() : require('containers/DevTools').instrument()
+      window.devToolsExtension ? window.devToolsExtension() : require('containers/DevTools').instrument()
     )
   } else {
     createStoreWithMiddleware = compose(middleware)

--- a/src/redux/configureStore.js
+++ b/src/redux/configureStore.js
@@ -14,7 +14,7 @@ export default function configureStore (initialState) {
   if (__DEBUG__) {
     createStoreWithMiddleware = compose(
       middleware,
-      require('containers/DevTools').instrument()
+      window.devToolsExtension() ? window.devToolsExtension() : require('containers/DevTools').instrument()
     )
   } else {
     createStoreWithMiddleware = compose(middleware)


### PR DESCRIPTION
This PR enables the use of the [redux-devtool-extension](https://github.com/zalmoxisus/redux-devtools-extension)  if available, instead of using redux-devtools-log-monitor/redux-devtools-dock-monitor.

PR #337 goes in that direction, but is a bit more complicated then necessary and produces a linter error. Also, it does not handle the "open devtools in new window" option correctly (I think one would expect that it to open redux-devtools-extension in a new window, not redux-devtools-log-monitor).

In redux-devtools-extension there is an option to open the extension programmatically (`window.devToolsExtension.open()`) which results in this: 

![redux devtools new window](http://i.imgur.com/fi6dLDv.png)

This is exactly the "npm run dev:nw" behavior, so if redux-devtools-extension is available, we'll use it.

The README should probably be updated too to reflect these changes.