### PR TITLE
fix(cssnano): Don't use unsafe cssnano options

### DIFF
--- a/build/webpack-environments/_base.js
+++ b/build/webpack-environments/_base.js
@@ -125,6 +125,7 @@ const webpackConfig = {
         remove: true,
         browsers: ['last 2 versions']
       },
+      safe: true,
       discardComments: {
         removeAll: true
       }


### PR DESCRIPTION
I was including a local (woff-)version of the Roboto font using `@font-face` in core.scss, because [react-toolbox](https://github.com/react-toolbox/react-toolbox) requires it to be available. However, it would not be available, nor would the `@font-face` show up in the css file that is generated after running compile in an production environment.

Turns out, it's because of cssnano. It has some [*unsafe* options](http://cssnano.co/optimisations/), for example [postcss-discard-unused](https://github.com/ben-eb/postcss-discard-unused), which removes `@counter-style`, `@keyframes` and `@font-face`  if it does not find any usage of the declared keyframe/font/counter-style in the same file.

Since we're using css-modules, the usage of a declared font or animation is very likely *not* to be in the same file, for example in my case Roboto was being used in some components scss files. But postcss-discard-unused removed the `@font-face` entry in this case, since there is no usage of Roboto in core.scss.

To solve this problem, we should disable the unsafe options.

[postcss-zindex](https://github.com/ben-eb/postcss-zindex), [postcss-merge-idents](https://github.com/ben-eb/postcss-merge-idents) and [postcss-reduce-idents](https://github.com/ben-eb/postcss-reduce-idents) are unsafe option, and they do not work well with multiple css files.

By setting `save`to `true`, we disable all 4 unsafe options ([source](https://github.com/ben-eb/cssnano/issues/28)).

For more information check http://cssnano.co/optimisations/