### PR TITLE
Make publicPath truly relative and configure history for basename

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,6 +12,7 @@
     "__PROD__"     : false,
     "__DEBUG__"    : false,
     "__DEBUG_NEW_WINDOW__" : false,
+    "__BASENAME__" : false,
     "React": true,
     "ReactDOM": true
   },

--- a/config/_base.js
+++ b/config/_base.js
@@ -35,7 +35,7 @@ const config = {
   compiler_hash_type       : 'hash',
   compiler_fail_on_warning : false,
   compiler_quiet           : false,
-  compiler_public_path     : '/',
+  compiler_public_path     : '',
   compiler_stats           : {
     chunks : false,
     chunkModules : false,
@@ -81,7 +81,8 @@ config.globals = {
   '__DEV__'      : config.env === 'development',
   '__PROD__'     : config.env === 'production',
   '__DEBUG__'    : config.env === 'development' && !argv.no_debug,
-  '__DEBUG_NEW_WINDOW__' : !!argv.nw
+  '__DEBUG_NEW_WINDOW__' : !!argv.nw,
+  '__BASENAME__' : JSON.stringify(process.env.BASENAME || '/')
 }
 
 // ------------------------------------

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "react-router": "^1.0.1",
     "redux": "^3.0.0",
     "redux-actions": "^0.9.0",
-    "redux-simple-router": "^1.0.0",
+    "redux-simple-router": "^1.0.1",
     "redux-thunk": "^1.0.0",
     "yargs": "^3.18.0"
   },

--- a/src/main.js
+++ b/src/main.js
@@ -1,10 +1,12 @@
-import createBrowserHistory from 'history/lib/createBrowserHistory'
+import { createHistory, useBasename } from 'history'
 import { syncReduxAndRouter } from 'redux-simple-router'
 import routes from './routes'
 import Root from './containers/Root'
 import configureStore from './redux/configureStore'
 
-const history = createBrowserHistory()
+const history = useBasename(createHistory)({
+  basename: __BASENAME__
+})
 const store = configureStore(window.__INITIAL_STATE__)
 
 syncReduxAndRouter(history, store, (state) => state.router)


### PR DESCRIPTION
A truly relative publicPath and the ability to configure a base path for React Router helps when deploying app in environments where its not served from the root path of the web server. The combination of changes lets you put the app arbitrarily deep, while still successfully serving resources and keeping route definitions defined in terms of '/'.