### PR TITLE
Modified compiler_public_path to undefined

### DIFF
--- a/config/_base.js
+++ b/config/_base.js
@@ -35,7 +35,7 @@ const config = {
   compiler_hash_type       : 'hash',
   compiler_fail_on_warning : false,
   compiler_quiet           : false,
-  compiler_public_path     : '/',
+  compiler_public_path     : undefined,
   compiler_stats           : {
     chunks : false,
     chunkModules : false,


### PR DESCRIPTION
I suggest to change the default value of compiler_public_path from '/' to undefined. Current value doesn't work when proxy sets prefix.

Current version creates the line below. The src is an absolute path, so it will not work if prefix like /deploy is set by proxy. 
```
<script src="/app.c3e1585f9dcb449f54f3.js"></script>
```
Proxy expects http://<host>/deploy/app.c3e1585f9dcb449f54f3.js, but the src is  http://<host>/app.c3e1585f9dcb449f54f3.js.

After changing compiler_public_path to undefined, the line becomes a relative path, which works well with proxy prefix. 
```
<script src="app.c3e1585f9dcb449f54f3.js"></script>
```
