### PR TITLE
Workaround issue with hot reloading

### DIFF
--- a/src/layouts/CoreLayout.js
+++ b/src/layouts/CoreLayout.js
@@ -1,11 +1,8 @@
 import '../styles/core.scss'
 
-// Note: Stateless/function components *will not* hot reload!
+/*
+// Note: Stateless/function components *will not* yet hot reload!
 // react-transform *only* works on component classes.
-//
-// Since layouts rarely change, they are a good place to
-// leverage React's new Statelesss Functions:
-// https://facebook.github.io/react/docs/reusable-components.html#stateless-functions
 //
 // CoreLayout is a pure function of it's props, so we can
 // define it with a plain javascript function...
@@ -21,6 +18,23 @@ function CoreLayout ({ children }) {
 
 CoreLayout.propTypes = {
   children: React.PropTypes.element
+}
+*/
+
+class CoreLayout extends React.Component {
+  static propTypes = {
+    children: React.PropTypes.element
+  }
+  render () {
+    const { children } = this.props
+    return (
+      <div className='page-container'>
+        <div className='view-container'>
+          {children}
+        </div>
+      </div>
+    )
+  }
 }
 
 export default CoreLayout

--- a/src/views/HomeView.js
+++ b/src/views/HomeView.js
@@ -12,9 +12,11 @@ const mapStateToProps = (state) => ({
   counter: state.counter
 })
 
-// React components can now be defined as pure functions
+/*
+// React components can be defined as pure functions
 // https://facebook.github.io/react/docs/reusable-components.html#stateless-functions
-function HomeView ({ counter, doubleAsync, increment }) {
+// This however causes karma tests fail
+export function HomeView ({ counter, doubleAsync, increment }) {
   return (
     <div className='container text-center'>
       <h1>Welcome to the React Redux Starter Kit</h1>
@@ -39,6 +41,37 @@ HomeView.propTypes = {
   counter: React.PropTypes.number.isRequired,
   doubleAsync: React.PropTypes.func.isRequired,
   increment: React.PropTypes.func.isRequired
+}
+*/
+
+export class HomeView extends React.Component {
+  static propTypes = {
+    counter: React.PropTypes.number.isRequired,
+    doubleAsync: React.PropTypes.func.isRequired,
+    increment: React.PropTypes.func.isRequired
+  }
+  render () {
+    const { counter, doubleAsync, increment } = this.props
+    return (
+      <div className='container text-center'>
+        <h1>Welcome to the React Redux Starter Kit</h1>
+        <h2>
+          Sample Counter:&nbsp;
+          <span className={styles['counter--green']}>{counter}</span>
+        </h2>
+        <button className='btn btn-default'
+                onClick={() => increment(1)}>
+          Increment
+        </button>
+        <button className='btn btn-default'
+                onClick={doubleAsync}>
+          Double (Async)
+        </button>
+        <hr />
+        <Link to='/about'>Go To About View</Link>
+      </div>
+    )
+  }
 }
 
 // Note: Stateless/function components *will not* yet hot reload!

--- a/src/views/HomeView.js
+++ b/src/views/HomeView.js
@@ -11,34 +11,50 @@ import styles from './HomeView.scss'
 const mapStateToProps = (state) => ({
   counter: state.counter
 })
-export class HomeView extends React.Component {
-  static propTypes = {
-    counter: React.PropTypes.number.isRequired,
-    doubleAsync: React.PropTypes.func.isRequired,
-    increment: React.PropTypes.func.isRequired
-  }
 
-  render () {
-    return (
-      <div className='container text-center'>
-        <h1>Welcome to the React Redux Starter Kit</h1>
-        <h2>
-          Sample Counter:&nbsp;
-          <span className={styles['counter--green']}>{this.props.counter}</span>
-        </h2>
-        <button className='btn btn-default'
-                onClick={() => this.props.increment(1)}>
-          Increment
-        </button>
-        <button className='btn btn-default'
-                onClick={this.props.doubleAsync}>
-          Double (Async)
-        </button>
-        <hr />
-        <Link to='/about'>Go To About View</Link>
-      </div>
-    )
-  }
+// React components can now be defined as pure functions
+// https://facebook.github.io/react/docs/reusable-components.html#stateless-functions
+function HomeView ({ counter, doubleAsync, increment }) {
+  return (
+    <div className='container text-center'>
+      <h1>Welcome to the React Redux Starter Kit</h1>
+      <h2>
+        Sample Counter:&nbsp;
+        <span className={styles['counter--green']}>{counter}</span>
+      </h2>
+      <button className='btn btn-default'
+              onClick={() => increment(1)}>
+        Increment
+      </button>
+      <button className='btn btn-default'
+              onClick={doubleAsync}>
+        Double (Async)
+      </button>
+      <hr />
+      <Link to='/about'>Go To About View</Link>
+    </div>
+  )
+}
+HomeView.propTypes = {
+  counter: React.PropTypes.number.isRequired,
+  doubleAsync: React.PropTypes.func.isRequired,
+  increment: React.PropTypes.func.isRequired
 }
 
-export default connect(mapStateToProps, counterActions)(HomeView)
+// Note: Stateless/function components *will not* yet hot reload!
+// react-transform *only* works on component classes.
+// https://github.com/gaearon/babel-plugin-react-transform/issues/57
+//
+// Since connected components don't need additional props, they can easily
+// be wrapped to support hot reloading.
+// Once the babel-plugin-react-transform issue has been resolved this class
+// maybe removed and the following used instead:
+//
+// export default connect(mapStateToProps, counterActions)(HomeView)
+//
+export default class Connector extends React.Component {
+  render () {
+    let Component = connect(mapStateToProps, counterActions)(HomeView)
+    return (<Component/>)
+  }
+}


### PR DESCRIPTION
babel-plugin-react-transform does not yet support functional components
https://github.com/gaearon/babel-plugin-react-transform/issues/57

This also breaks "connect" so modifications to actions and
mapStateToProps does not hot reload.

Wrapping the connect call in another component fixes this and allows use
of functional components. Since connected components do not need extra
props wrapping connected components is easier than wrapping layout
components, thus I converted CoreLayout back to a class