### PR TITLE
fix: remove node_modules from the coverage report

### DIFF
--- a/build/karma.conf.js
+++ b/build/karma.conf.js
@@ -46,7 +46,8 @@ if (config.coverage_enabled) {
   karmaConfig.webpack.module.preLoaders = [{
     test: /\.(js|jsx)$/,
     include: new RegExp(config.dir_client),
-    loader: 'isparta'
+    loader: 'isparta',
+    exclude: /node_modules/
   }]
 }
 


### PR DESCRIPTION
For some reason an npm package was getting included in my coverage reports.  Adding this `exclude` made it stop running coverage on the npm package.  The package was `js-cookie` in case you were wondering.  Not sure if this is actually a necessary PR or if I was just doing something silly in my code. 