### PR TITLE
feat(webpack): component name resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,18 +180,43 @@ You can redefine which packages to bundle separately by modifying `compiler_vend
 ]
 ```
 
-### Webpack Root Resolve
-Webpack is configured to make use of [resolve.root](http://webpack.github.io/docs/configuration.html#resolve-root), which lets you import local packages as if you were traversing from the root of your `~/src` directory. Here's an example:
+### Webpack Resolvers
+Webpack is configured to make use of several shortcuts that help make imports more flexible, modular and DRY:
+ - [resolve.root](http://webpack.github.io/docs/configuration.html#resolve-root) lets you import local packages as if you were traversing from the root of your `~/src` directory.
+ - [component-resolver-webpack](https://github.com/toptal/component-resolver-webpack) shortcut for resolving components with filenames that match their directory names, the widely accepted convention for modular react components used in this projecs.
 
+**Using `resolve.root`:**
 ```js
-// current file: ~/src/views/some/nested/View.js
-
 // What used to be this:
-import SomeComponent from '../../../components/SomeComponent'
+import SomeComponent from '../../../components/SomeComponent/SomeComponent.js'
 
 // Can now be this:
-import SomeComponent from 'components/SomeComponent' // Hooray!
+import SomeComponent from 'components/SomeComponent/SomeComponent' // Hooray!
 ```
+
+No more relative imports! Not only is this is a nice shortcut, resolving `import` from the root makes our structure much more flexible.
+
+But did you notice the redudent `SomeComponent/SomeComponent` reference? That's a code smell that is an unfortunate result of the following modern convention for organizing component project structure:
+> The component file should be placed in a directory named as component itself e.g `Button.jsx` must be placed inside `Button` directorty: `Button/Button.jsx`.
+
+That's where the component resolver plugin comes in...
+
+**Using `resolve.root` and component resolver:**
+
+```js
+// relative import:
+import SomeComponent from '../../../components/SomeComponent/SomeComponent.js'
+
+// using root and extension resolvers (current setup)
+import SomeComponent from 'components/SomeComponent/SomeComponent'
+
+// using component resolver plugin
+import SomeComponent from 'components/SomeComponent'  // Boom!
+```
+
+Note that standard import syntax and behavior are not affected, so the former import and require methods will still work.
+
+### 
 
 ### Globals
 

--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -2,6 +2,7 @@ import webpack from 'webpack'
 import cssnano from 'cssnano'
 import HtmlWebpackPlugin from 'html-webpack-plugin'
 import ExtractTextPlugin from 'extract-text-webpack-plugin'
+import ComponentResolverPlugin from 'component-resolver-webpack'
 import config from '../config'
 import _debug from 'debug'
 
@@ -45,6 +46,9 @@ webpackConfig.output = {
 // Plugins
 // ------------------------------------
 webpackConfig.plugins = [
+  new webpack.ResolverPlugin([
+    new ComponentResolverPlugin()
+  ]),
   new webpack.DefinePlugin(config.globals),
   new webpack.optimize.OccurrenceOrderPlugin(),
   new webpack.optimize.DedupePlugin(),

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "babel-runtime": "^6.3.19",
     "chai": "^3.4.1",
     "chai-as-promised": "^5.1.0",
+    "component-resolver-webpack": "^0.4.0",
     "css-loader": "^0.23.0",
     "cssnano": "^3.3.2",
     "eslint": "^1.10.3",

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -6,9 +6,22 @@ import { Route, IndexRoute, Redirect } from 'react-router'
 // they were from the root of the ~/src directory. This makes it
 // very easy to navigate to files regardless of how deeply nested
 // your current file is.
-import CoreLayout from 'layouts/CoreLayout/CoreLayout'
-import HomeView from 'views/HomeView/HomeView'
-import NotFoundView from 'views/NotFoundView/NotFoundView'
+//
+// We are also using a webpack resolver plugin to provide an easy
+// shortcut for referencing components nested in directories with
+// matching file names (our convention) so instead of:
+//
+//    import CoreLayout from 'layouts/CoreLayout/CoreLayout'
+//
+// we can just use:
+//
+//    import CoreLayout from 'layouts/CoreLayout'
+//
+// which will resolve to the correct file
+
+import CoreLayout from 'layouts/CoreLayout'
+import HomeView from 'views/HomeView'
+import NotFoundView from 'views/NotFoundView'
 
 export default (
   <Route path='/' component={CoreLayout}>


### PR DESCRIPTION
simple plugin to resolve nested components with filenames that match directory names... instead of:
```js
// full path
import CoreLayout from 'src/layouts/CoreLayout/CoreLayout.js'
```
```js
// using root and extension resolvers (current setup)
import CoreLayout from 'layouts/CoreLayout/CoreLayout'
```
after this PR, we can use the shortcut:
```js
// using component resolver plugin
import CoreLayout from 'layouts/CoreLayout'
```
standard import syntax and behavior are not affected, so the former methods will still work

