### PR TITLE
fix(webpack): re-add loader for css

### DIFF
--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -141,6 +141,16 @@ webpackConfig.module.loaders.push({
   ]
 })
 
+webpackConfig.module.loaders.push({
+  test: /\.css$/,
+  include: /src/,
+  loaders: [
+    'style',
+    cssLoader,
+    'postcss'
+  ]
+})
+
 // Don't treat global SCSS as modules
 webpackConfig.module.loaders.push({
   test: /\.scss$/,


### PR DESCRIPTION
For some reason this loader was dropped on consolidating configuration commit:

https://github.com/davezuko/react-redux-starter-kit/commit/a86512777294eebba1349fc5a2d692c8e71726c1#diff-2aa085fcb2f0f27da800b7ffc26fb9d9L91