### PR TITLE
fix(karma): add sourcemap to get better references

### DIFF
--- a/build/karma.conf.js
+++ b/build/karma.conf.js
@@ -19,7 +19,7 @@ const karmaConfig = {
   singleRun: !argv.watch,
   frameworks: ['mocha', 'chai-sinon', 'chai-as-promised', 'chai'],
   preprocessors: {
-    [`${config.dir_test}/test-bundler.js`]: ['webpack']
+    [`${config.dir_test}/test-bundler.js`]: ['webpack', 'sourcemap']
   },
   reporters: ['spec'],
   browsers: ['PhantomJS'],

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "karma-coverage": "^0.5.0",
     "karma-mocha": "^0.2.0",
     "karma-phantomjs-launcher": "^0.2.1",
+    "karma-sourcemap-loader": "^0.3.7",
     "karma-spec-reporter": "0.0.23",
     "karma-webpack": "^1.7.0",
     "mocha": "^2.2.5",


### PR DESCRIPTION
All the errors and failed tests of Karma reference just to the `test-bundler.js` and I think that's so useless information for a developer that I consider it a bug. For example:

```
(View) Home
    ✓ Should render as a <div>.
    ✗ Should include an <h1> with welcome text.
	Error: Did not find exactly one match for tag:h1
	    at /Library/xxxxx/react/tests/test-bundler.js:48953
	    at /Library/xxxxx/react/tests/test-bundler.js:31020
```

I was able to fix that using `karma-sourcemap-loader` and now the output looks like this:

```
(View) Home
  ✓ Should render as a <div>.
  ✗ Should include an <h1> with welcome text.
	Error: Did not find exactly one match for tag:h1
	    at /Library/xxxxx/react/tests/test-bundler.js:48953 <- webpack:///~/react/lib/ReactTestUtils.js:206:
	    at /Library/xxxxx/react/tests/test-bundler.js:31020 <- webpack:///tests/views/HomeView.spec.js:37:4
```

I really don't know how far from perfect the fix is, but the issue is gone!