### PR TITLE
Add `send` function for middleware decorated `res`

### DIFF
--- a/server/middleware/webpack-dev.js
+++ b/server/middleware/webpack-dev.js
@@ -22,6 +22,10 @@ export default function (compiler, publicPath) {
   return async function koaWebpackDevMiddleware (ctx, next) {
     let hasNext = await applyExpressMiddleware(middleware, ctx.req, {
       end: (content) => ctx.body = content,
+      send: (content) => {
+        ctx.body = content
+        ctx.res.end(content)
+      },
       setHeader: function () {
         ctx.set.apply(ctx, arguments)
       }


### PR DESCRIPTION
Fixes this issue:

```
.../react-redux-starter-kit/server/middleware/webpack-dev.js:41
                  ctx.res.send(content);
                          ^

TypeError: ctx.res.send is not a function
    at Object.send (webpack-dev.js:28:17)
    at processRequest (.../react-redux-starter-kit/node_modules/webpack-dev-middleware/middleware.js:189:8)
    at continueBecauseBundleAvailible (.../react-redux-starter-kit/node_modules/webpack-dev-middleware/middleware.js:59:5)
    at Array.forEach (native)
    at .../react-redux-starter-kit/node_modules/webpack-dev-middleware/middleware.js:58:8
    at nextTickCallbackWith0Args (node.js:452:9)
    at process._tickCallback (node.js:381:13)
[nodemon] app crashed - waiting for file changes before starting...
```

I'm not that familiar with the inner workings of this decorated `res` object; so my solution may be conceptually wrong.

Thanks