### PR TITLE
fix res. Pinned 1.4.0 version of webpack-dev-middleware due to incompatability…

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "style-loader": "^0.13.0",
     "url-loader": "^0.5.6",
     "webpack": "1.12.9",
-    "webpack-dev-middleware": "^1.4.0",
+    "webpack-dev-middleware": "1.4.0",
     "webpack-hot-middleware": "^2.6.0"
   }
 }


### PR DESCRIPTION
Resolves issue with new version of webpack-dev-middleware

```
TypeError: res.send is not a function
    at processRequest (/home/gbelken/Projects/clones/react-redux-starter-kit/node_modules/webpack-dev-middleware/middleware.js:189:8)
    at continueBecauseBundleAvailible (/home/gbelken/Projects/clones/react-redux-starter-kit/node_modules/webpack-dev-middleware/middleware.js:59:5)
    at Array.forEach (native)
    at /home/gbelken/Projects/clones/react-redux-starter-kit/node_modules/webpack-dev-middleware/middleware.js:58:8
    at nextTickCallbackWith0Args (node.js:456:9)
    at process._tickCallback (node.js:385:13)
```