### PR TITLE
Providing user feedback: block the double button on click

### DIFF
--- a/src/redux/modules/counter.js
+++ b/src/redux/modules/counter.js
@@ -1,4 +1,5 @@
 import { createAction, handleActions } from 'redux-actions'
+import { fetch, endFetch } from './fetching'
 
 // ------------------------------------
 // Constants
@@ -18,8 +19,9 @@ export const increment = createAction(COUNTER_INCREMENT, (value = 1) => value)
 // reducer take care of this logic.
 export const doubleAsync = () => {
   return (dispatch, getState) => {
+    dispatch(fetch())
     setTimeout(() => {
-      dispatch(increment(getState().counter))
+      dispatch([endFetch(), increment(getState().counter)])
     }, 1000)
   }
 }

--- a/src/redux/modules/fetching.js
+++ b/src/redux/modules/fetching.js
@@ -1,0 +1,14 @@
+import { createAction, handleActions } from 'redux-actions'
+
+export const BEGIN_FETCHING = 'BEGIN_FETCHING'
+export const END_FETCHING = 'END_FETCHING'
+
+export const fetch = createAction(BEGIN_FETCHING, () => true)
+export const endFetch = createAction(END_FETCHING, () => false)
+
+export const actions = { fetch, endFetch }
+
+export default handleActions({
+  [BEGIN_FETCHING]: (state, { payload }) => payload,
+  [END_FETCHING]: (state, { payload }) => payload
+}, false)

--- a/src/redux/rootReducer.js
+++ b/src/redux/rootReducer.js
@@ -1,8 +1,10 @@
 import { combineReducers } from 'redux'
 import { routeReducer as router } from 'redux-simple-router'
 import counter from './modules/counter'
+import fetching from './modules/fetching'
 
 export default combineReducers({
+  fetching,
   counter,
   router
 })

--- a/src/views/HomeView/HomeView.js
+++ b/src/views/HomeView/HomeView.js
@@ -2,6 +2,7 @@ import React, { PropTypes } from 'react'
 import { connect } from 'react-redux'
 import { Link } from 'react-router'
 import { actions as counterActions } from '../../redux/modules/counter'
+import { actions as fetchingActions } from '../../redux/modules/fetching'
 import DuckImage from './Duck.jpg'
 import classes from './HomeView.scss'
 
@@ -11,10 +12,12 @@ import classes from './HomeView.scss'
 // the component can be tested w/ and w/o being connected.
 // See: http://rackt.github.io/redux/docs/recipes/WritingTests.html
 const mapStateToProps = (state) => ({
-  counter: state.counter
+  counter: state.counter,
+  fetching: state.fetching
 })
 export class HomeView extends React.Component {
   static propTypes = {
+    fetching: PropTypes.bool.isRequired,
     counter: PropTypes.number.isRequired,
     doubleAsync: PropTypes.func.isRequired,
     increment: PropTypes.func.isRequired
@@ -42,8 +45,9 @@ export class HomeView extends React.Component {
         </button>
         {' '}
         <button className='btn btn-default'
+                disabled={this.props.fetching}
                 onClick={this.props.doubleAsync}>
-          Double (Async)
+          { this.props.fetching ? 'Wait...' : 'Double (Async)' }
         </button>
         <hr />
         <Link to='/404'>Go to 404 Page</Link>
@@ -52,4 +56,4 @@ export class HomeView extends React.Component {
   }
 }
 
-export default connect(mapStateToProps, counterActions)(HomeView)
+export default connect(mapStateToProps, Object.assign({}, counterActions, fetchingActions))(HomeView)

--- a/tests/views/HomeView.spec.js
+++ b/tests/views/HomeView.spec.js
@@ -25,6 +25,7 @@ describe('(View) Home', function () {
     _spies = {}
     _props = {
       counter: 0,
+      fetching: false,
       ...bindActionCreators({
         doubleAsync: (_spies.doubleAsync = sinon.spy()),
         increment: (_spies.increment = sinon.spy())


### PR DESCRIPTION
A feature that is usually needed is the ability to block a button until a request finishes, as users are used to get the feedback that something is going on.

This pull request implements such a feature for the async button. UX looks good, but I have my doubts regarding the implementation.

I feel that this concept should actually be turned into a small library that would wrap a button, set up a "namespace" in the state to handle different buttons, and provide some way to easily incorporate the reducers. I'm new to `redux` development, but I'm fascinated by the mental model. I'm also wary about the dependence between the different actions... looks like it could escalate very quickly to a code mess.

I'd appreciate any feedback that you have on this idea.

Thanks for your work!