### PR TITLE
Load HMR using public rather than relative path.

### DIFF
--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -27,7 +27,7 @@ const APP_ENTRY_PATH = paths.base(config.dir_client) + '/main.js'
 
 webpackConfig.entry = {
   app: __DEV__
-    ? [APP_ENTRY_PATH, 'webpack-hot-middleware/client?path=/__webpack_hmr']
+    ? [APP_ENTRY_PATH, `webpack-hot-middleware/client?path=${config.compiler_public_path}__webpack_hmr`]
     : [APP_ENTRY_PATH],
   vendor: config.compiler_vendor
 }


### PR DESCRIPTION
I'm using react-redux-starter-kit with django (utilising [django-webpack-loader](https://github.com/owais/django-webpack-loader) and [webpack-bundle-tracker](https://github.com/owais/webpack-bundle-tracker)) and the requests for `__webpack_hmr` fail because they are being attempted relatively.