### PR TITLE
Change lint to pickup jsx files too

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "clean": "rm -rf dist",
     "compile": "node -r dotenv/config --harmony bin/compile",
-    "lint": "eslint . ./",
+    "lint": "eslint --est=js --est=jsx . ./",
     "lint:fix": "npm run lint -- --fix",
     "start": "better-npm-run start",
     "dev": "better-npm-run dev",


### PR DESCRIPTION
flags needed to that jsx files are linted too.  see: https://github.com/eslint/eslint/issues/801