### PR TITLE
update react-router to 2.0.0, user browserHistory

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "react": "^0.14.0",
     "react-dom": "^0.14.0",
     "react-redux": "^4.0.0",
-    "react-router": "^2.0.0-rc5",
+    "react-router": "^2.0.0",
     "react-router-redux": "^3.0.0",
     "redux": "^3.0.0",
     "redux-thunk": "^1.0.0",

--- a/src/main.js
+++ b/src/main.js
@@ -1,13 +1,9 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { useRouterHistory } from 'react-router'
-import { createHistory } from 'history'
+import { browserHistory } from 'react-router'
 import makeRoutes from './routes'
 import Root from './containers/Root'
 import configureStore from './redux/configureStore'
-
-const historyConfig = { basename: __BASENAME__ }
-const history = useRouterHistory(createHistory)(historyConfig)
 
 const initialState = window.__INITIAL_STATE__
 const store = configureStore({ initialState, history })
@@ -16,6 +12,6 @@ const routes = makeRoutes(store)
 
 // Render the React application to the DOM
 ReactDOM.render(
-  <Root history={history} routes={routes} store={store} />,
+  <Root history={browserHistory} routes={routes} store={store} />,
   document.getElementById('root')
 )


### PR DESCRIPTION
in main.js, if you use createHistory, you cannot use [recommended practices](https://github.com/rackt/react-router/blob/latest/docs/guides/NavigatingOutsideOfComponents.md) for transitioning routes via global browserHistory singleton.

Solves issue https://github.com/rackt/react-router/issues/3062

