### PR TITLE
fix(config): make Redux actions work with store

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -7,17 +7,17 @@ import makeRoutes from './routes'
 import Root from './containers/Root'
 import configureStore from './redux/configureStore'
 
+// Configure history for react-router
+const browserHistory = useRouterHistory(createBrowserHistory)({
+  basename: __BASENAME__
+})
+
 // Create redux store and sync with react-router-redux. We have installed the
 // react-router-redux reducer under the key "router" in src/routes/index.js,
 // so we need to provide a custom `selectLocationState` to inform
 // react-router-redux of its location.
 const initialState = window.__INITIAL_STATE__
-const store = configureStore(initialState)
-
-// Configure history for react-router
-const browserHistory = useRouterHistory(createBrowserHistory)({
-  basename: __BASENAME__
-})
+const store = configureStore(initialState, browserHistory)
 const history = syncHistoryWithStore(browserHistory, store, {
   selectLocationState: (state) => state.router
 })

--- a/src/redux/configureStore.js
+++ b/src/redux/configureStore.js
@@ -1,10 +1,11 @@
 import { applyMiddleware, compose, createStore } from 'redux'
 import thunk from 'redux-thunk'
 import rootReducer from './rootReducer'
+import { routerMiddleware } from 'react-router-redux'
 
-export default function configureStore (initialState = {}) {
+export default function configureStore (initialState = {}, history) {
   // Compose final middleware and use devtools in debug environment
-  let middleware = applyMiddleware(thunk)
+  let middleware = applyMiddleware(thunk, routerMiddleware(history))
   if (__DEBUG__) {
     const devTools = window.devToolsExtension
       ? window.devToolsExtension()


### PR DESCRIPTION
```
// Dispatch from anywhere like normal.
store.dispatch(push('/foo'))
```