### PR TITLE
Made the app link clickable

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -7,4 +7,4 @@ const port = config.server_port
 const host = config.server_host
 
 server.listen(port)
-debug(`Server is now running at ${host}:${port}.`)
+debug(`Server is now running at http://${host}:${port}.`)


### PR DESCRIPTION
This small change makes the link clickable in some terminal emulators (like xfce-terminal), which makes it easier to open the app in a browser.