### PR TITLE
Updated eslint to 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "css-loader": "^0.23.0",
     "cssnano": "^3.3.2",
     "enzyme": "^1.5.0",
-    "eslint": "2.0.0-rc.1",
+    "eslint": "^2.1.0",
     "eslint-config-standard": "^5.1.0",
     "eslint-config-standard-react": "^2.2.0",
     "eslint-loader": "^1.1.1",


### PR DESCRIPTION
It works perfectly on npm@3, but temporarily could cause issues on npm@2 because of this bug:
https://github.com/feross/standard/issues/406