### PR TITLE
fix(webpack) Altered config to fix generated resource links

### DIFF
--- a/config/_development.js
+++ b/config/_development.js
@@ -2,7 +2,7 @@
 // to fix this issue:
 // http://stackoverflow.com/questions/34133808/webpack-ots-parsing-error-loading-fonts/34133809#34133809
 export default (config) => ({
-  compiler_public_path: `http://${config.server_host}:${config.server_port}/`,
+  compiler_public_path: `/`,
   proxy: {
     enabled: false,
     options: {

--- a/config/_development.js
+++ b/config/_development.js
@@ -2,7 +2,7 @@
 // to fix this issue:
 // http://stackoverflow.com/questions/34133808/webpack-ots-parsing-error-loading-fonts/34133809#34133809
 export default (config) => ({
-  compiler_public_path: `http://${config.server_host}:${config.server_port}/`,
+  compiler_public_path: '/',
   proxy: {
     enabled: false,
     options: {

--- a/config/_development.js
+++ b/config/_development.js
@@ -2,7 +2,7 @@
 // to fix this issue:
 // http://stackoverflow.com/questions/34133808/webpack-ots-parsing-error-loading-fonts/34133809#34133809
 export default (config) => ({
-  compiler_public_path: '/',
+  compiler_public_path: `http://${config.server_host}:${config.server_port}/`,
   proxy: {
     enabled: false,
     options: {

--- a/config/_production.js
+++ b/config/_production.js
@@ -1,5 +1,6 @@
 /* eslint key-spacing:0 */
 export default () => ({
+  compiler_public_path: '/',
   compiler_fail_on_warning : false,
   compiler_hash_type       : 'chunkhash',
   compiler_devtool         : null,

--- a/config/_production.js
+++ b/config/_production.js
@@ -1,5 +1,6 @@
 /* eslint key-spacing:0 */
 export default () => ({
+  compiler_public_path     : `/`,
   compiler_fail_on_warning : false,
   compiler_hash_type       : 'chunkhash',
   compiler_devtool         : null,

--- a/config/_production.js
+++ b/config/_production.js
@@ -1,6 +1,5 @@
 /* eslint key-spacing:0 */
 export default () => ({
-  compiler_public_path: '/',
   compiler_fail_on_warning : false,
   compiler_hash_type       : 'chunkhash',
   compiler_devtool         : null,


### PR DESCRIPTION
We found an issue where generated webpack files app.* and vendor.* were not being linked correctly when deployed to production. Specifying the compiler_public_path in the config fixed the issue for us.