### PR TITLE
Adds redux-cli blueprints to starter kit

### DIFF
--- a/.reduxrc
+++ b/.reduxrc
@@ -1,0 +1,8 @@
+{
+  "sourceBase":"src",
+  "testBase":"tests",
+  "smartPath":"containers",
+  "dumbPath":"components",
+  "fileCasing":"pascal"
+}
+

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Table of Contents
 1. [Server](#server)
 1. [Styles](#styles)
 1. [Testing](#testing)
+1. [CLI Generators](#cli-generators)
 1. [Deployment](#deployment)
 1. [Troubleshooting](#troubleshooting)
 
@@ -88,7 +89,13 @@ $ npm start                     # Compile and launch
 Starting a New Project
 ----------------------
 
-First, I highly suggest checking out a new project by [SpencerCDixon](https://github.com/SpencerCDixon): [redux-cli](https://github.com/SpencerCDixon/redux-cli). This tool integrates extremely well with this project and offers added benefits such as generators (components, redux modules, etc.) and config/template management. It's still a work in progress, but give it a shot.
+First, I highly suggest checking out a new project by
+[SpencerCDixon](https://github.com/SpencerCDixon):
+[redux-cli](https://github.com/SpencerCDixon/redux-cli). This tool integrates
+extremely well with this project and offers added benefits such as generators
+(components, redux modules, etc.) and config/template management. It's still a
+work in progress, but give it a shot and file bugs to help make the project more
+robust.
 
 Alternatively, if you just want to stick with this project and want to start a fresh project without having to clean up the example code in `master`, you can do the following after cloning the repo:
 
@@ -252,6 +259,31 @@ Testing
 To add a unit test, simply create a `.spec.js` file anywhere in `~/tests`. Karma will pick up on these files automatically, and Mocha and Chai will be available within your test without the need to import them.
 
 Coverage reports will be compiled to `~/coverage` by default. If you wish to change what reporters are used and where reports are compiled, you can do so by modifying `coverage_reporters` in `~/config/_base.js`.
+
+CLI Generators
+--------------
+If you used the [Redux CLI](https://github.com/SpencerCDixon/redux-cli) to
+generate your project a number of blueprints are available (which you can override).
+The generated files live in the `blueprints` folder so you can customize the
+generators for your projects specific needs.
+
+If you have an existing app you can run `redux init` to set up the CLI, then
+make sure to copy over the `blueprints` folder in this project for starter-kit
+specific generators.
+
+[See the Redux CLI github repo](https://github.com/SpencerCDixon/redux-cli#creating-blueprints) for more information on how to create and use
+blueprints.
+
+|Name|Description|Options|
+|---|---|---|
+|`redux g dumb <comp name>`|generates a dumb component and test file||
+|`redux g smart <smart name>`|generates a smart connected component and test file||
+|`redux g layout <comp name>`|generates functional layout component||
+|`redux g view <comp name>`|generates a view component||
+|`redux g form <form name>`|generates a form component (assumes redux-form)||
+|`redux g duck <duck name>`|generates a redux duck and test file||
+|`redux g blueprint <new blueprint>`|generates an empty blueprint for you to make||
+
 
 Deployment
 ----------

--- a/blueprints/blueprint/files/blueprints/__name__/files/.gitkeep
+++ b/blueprints/blueprint/files/blueprints/__name__/files/.gitkeep
@@ -1,0 +1,1 @@
+put your files here

--- a/blueprints/blueprint/files/blueprints/__name__/index.js
+++ b/blueprints/blueprint/files/blueprints/__name__/index.js
@@ -1,0 +1,25 @@
+module.exports = {
+  locals: function(options) {
+    // Return custom template variables here.
+    return {};
+  },
+
+  fileMapTokens: function(options) (
+    // Return custom tokens to be replaced in your files
+    return {
+      __token__: function(options){
+        // logic to determine value goes here
+        return 'value';
+      }
+    }
+  },
+
+  // Should probably never need to be overriden
+
+  filesPath: function() {
+    return path.join(this.path, 'files');
+  },
+
+  beforeInstall: function(options) {},
+  afterInstall: function(options) {},
+};

--- a/blueprints/blueprint/index.js
+++ b/blueprints/blueprint/index.js
@@ -1,0 +1,13 @@
+module.exports = {
+  description() {
+    return 'generates a blueprint and definition';
+  },
+
+  beforeInstall() {
+    console.log('Before installation hook!');
+  },
+
+  afterInstall() {
+    console.log('After installation hook!');
+  }
+};

--- a/blueprints/duck/files/__root__/redux/modules/__name__.js
+++ b/blueprints/duck/files/__root__/redux/modules/__name__.js
@@ -1,0 +1,19 @@
+// Constants
+
+// export const constants = { };
+
+// Action Creators
+
+// export const actions = { };
+
+// Reducer
+export const defaultState = {
+};
+
+export default function(state = defaultState, action) {
+  switch (action.type) {
+    default:
+      return state;
+  }
+}
+

--- a/blueprints/duck/files/__test__/redux/modules/__name__.test.js
+++ b/blueprints/duck/files/__test__/redux/modules/__name__.test.js
@@ -1,0 +1,10 @@
+import reducer, { defaultState } from 'redux/modules/<%= pascalEntityName %>';
+import deepFreeze from 'deep-freeze';
+
+describe('(Redux) <%= pascalEntityName %>', () => {
+  describe('(Reducer)', () => {
+    it('sets up initial state', () => {
+      expect(reducer(undefined, {})).to.eql(defaultState);
+    });
+  });
+});

--- a/blueprints/duck/index.js
+++ b/blueprints/duck/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+  description() {
+    return 'generates a redux duck';
+  }
+};

--- a/blueprints/dumb/files/__root__/components/__name__.js
+++ b/blueprints/dumb/files/__root__/components/__name__.js
@@ -1,0 +1,15 @@
+import React, { Component, PropTypes } from 'react';
+
+const propTypes = {
+};
+
+class <%= pascalEntityName %> extends Component {
+  render() {
+    return (
+    )
+  }
+}
+
+<%= pascalEntityName %>.propTypes = propTypes;
+export default <%= pascalEntityName %>;
+

--- a/blueprints/dumb/files/__test__/components/__name__.test.js
+++ b/blueprints/dumb/files/__test__/components/__name__.test.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+describe('(Component) <%= pascalEntityName %>', function() {
+  it('should exist', function() {
+
+  });
+});

--- a/blueprints/dumb/index.js
+++ b/blueprints/dumb/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+  description() {
+    return 'generates a dumb (pure) component';
+  }
+};

--- a/blueprints/form/files/__root__/forms/__name__Form.js
+++ b/blueprints/form/files/__root__/forms/__name__Form.js
@@ -1,0 +1,37 @@
+import React, { Component, PropTypes } from 'react';
+import { reduxForm } from 'redux-form';
+
+export const fields = [];
+
+const validate = (values) => {
+  const errors = {};
+  return errors;
+};
+
+const propTypes = {
+  handleSubmit: PropTypes.func.isRequired,
+  fields: PropTypes.object.isRequired
+};
+
+export class <%= pascalEntityName %> extends Component {
+  render() {
+    const {
+      fields: {},
+      handleSubmit
+    } = this.props;
+
+    return (
+      <form onSubmit={handleSubmit}>
+      </form>
+    );
+  }
+}
+
+<%= pascalEntityName %>.propTypes = propTypes;
+<%= pascalEntityName %> = reduxForm({
+  form: '<%= pascalEntityName %>',
+  fields,
+  validate
+})(<%= pascalEntityName %>);
+
+export default <%= pascalEntityName %>;

--- a/blueprints/form/files/__test__/forms/__name__Form.test.js
+++ b/blueprints/form/files/__test__/forms/__name__Form.test.js
@@ -1,0 +1,5 @@
+describe('(Form) <%= pascalEntityName %>', () => {
+  it('exists', () => {
+
+  });
+});

--- a/blueprints/form/index.js
+++ b/blueprints/form/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+  description() {
+    return 'generates a connected redux-form form component';
+  }
+};

--- a/blueprints/layout/files/__root__/layouts/__name__Layout/__name__Layout.js
+++ b/blueprints/layout/files/__root__/layouts/__name__Layout/__name__Layout.js
@@ -1,0 +1,15 @@
+import React, { PropTypes } from 'react'
+
+function <%= pascalEntityName %> ({ children }) {
+  return (
+    <div className='<%= snakeEntityName %>-layout'>
+      {children}
+    </div>
+  )
+}
+
+<%= pascalEntityName %>.propTypes = {
+  children: PropTypes.element
+}
+
+export default <%= pascalEntityName %>

--- a/blueprints/layout/files/__test__/layouts/__name__Layout.test.js
+++ b/blueprints/layout/files/__test__/layouts/__name__Layout.test.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+describe('(Layout) <%= pascalEntityName %>', function() {
+  it('should exist', function() {
+
+  });
+});

--- a/blueprints/layout/index.js
+++ b/blueprints/layout/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+  description() {
+    return 'generates a functional layout component';
+  }
+};

--- a/blueprints/smart/files/__root__/containers/__name__.js
+++ b/blueprints/smart/files/__root__/containers/__name__.js
@@ -1,0 +1,28 @@
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+
+const propTypes = {
+};
+
+class <%= pascalEntityName %> extends Component {
+  render() {
+    return (
+
+    )
+  }
+}
+
+const mapStateToProps = (state) => {
+  return {};
+}
+const mapDispatchToProps = (dispatch) => {
+  return {};
+}
+
+<%= pascalEntityName %>.propTypes = propTypes;
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(<%= pascalEntityName %>);
+

--- a/blueprints/smart/files/__test__/containers/__name__.test.js
+++ b/blueprints/smart/files/__test__/containers/__name__.test.js
@@ -1,0 +1,5 @@
+describe('(Component) <%= pascalEntityName %>', () => {
+  it('exists', () => {
+
+  });
+});

--- a/blueprints/smart/index.js
+++ b/blueprints/smart/index.js
@@ -1,0 +1,12 @@
+module.exports = {
+  description() {
+    return 'generates a smart (container) component';
+  },
+  fileMapTokens() {
+    return {
+      __smart__: (options) => {
+        return options.settings.getSetting('smartPath');
+      }
+    }
+  }
+};

--- a/blueprints/view/files/__root__/views/__name__View/__name__View.js
+++ b/blueprints/view/files/__root__/views/__name__View/__name__View.js
@@ -1,0 +1,15 @@
+import React, { PropTypes } from 'react'
+
+function <%= pascalEntityName %> ({ children }) {
+  return (
+    <div className='<%= snakeEntityName %>-layout'>
+      {children}
+    </div>
+  )
+}
+
+<%= pascalEntityName %>.propTypes = {
+  children: PropTypes.element
+}
+
+export default <%= pascalEntityName %>

--- a/blueprints/view/files/__test__/views/__name__View.test.js
+++ b/blueprints/view/files/__test__/views/__name__View.test.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+describe('(View) <%= pascalEntityName %>', function() {
+  it('should exist', function() {
+
+  });
+});

--- a/blueprints/view/index.js
+++ b/blueprints/view/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+  description() {
+    return 'generates a view component';
+  }
+};


### PR DESCRIPTION
By putting blueprints inside the starter kit it allows users to easily find and override the templates to their teams specific needs.  As the starter kits conventions change and evolve the blueprints can be updated internally as well therefore eliminating the need for me to always be up to date with what's going on in the starter kit.

Let me know if you need any more explanation from me as far as what this PR is doing or if I messed up any of the contributing conventions!

Cheers