### PR TITLE
fix(eslint): pin eslint to ~2.2.0 to avoid missing estraverse-fb

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "css-loader": "^0.23.0",
     "cssnano": "^3.3.2",
     "enzyme": "^2.0.0",
-    "eslint": "^2.1.0",
+    "eslint": "~2.2.0",
     "eslint-config-standard": "^5.1.0",
     "eslint-config-standard-react": "^2.2.0",
     "eslint-loader": "^1.1.1",


### PR DESCRIPTION
Fixes #629