### PR TITLE
Remove strip_root from .flow_config in order to keep Nuclide happy

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -40,7 +40,6 @@ module.name_mapper='^views\/\(.*\)$' -> '<PROJECT_ROOT>/src/views/\1'
 module.name_mapper='^views$' -> '<PROJECT_ROOT>/src/views'
 
 munge_underscores=true
-strip_root=true
 
 suppress_type=$FlowIssue
 suppress_type=$FlowFixMe


### PR DESCRIPTION
Out-of-the-box nuclide appears to choke on the `strip_root` flag