### PR TITLE
'/' path for 'compiler_public_path' has been added.

### DIFF
--- a/config/_base.js
+++ b/config/_base.js
@@ -30,7 +30,7 @@ const config = {
   compiler_hash_type       : 'hash',
   compiler_fail_on_warning : false,
   compiler_quiet           : false,
-  compiler_public_path     : '',
+  compiler_public_path     : '/',
   compiler_stats           : {
     chunks : false,
     chunkModules : false,


### PR DESCRIPTION
'/' path for 'compiler_public_path' has been added since compiled assets are unable to be loaded when the param-included route URL directly accessed.

This change adds '/' in front of URL that presents the location of complied assets in 'index.html' in 'dist' directory.
