### PR TITLE
Use babel-polyfill instead of phantomjs-polyfill in karma.conf

### DIFF
--- a/build/karma.conf.js
+++ b/build/karma.conf.js
@@ -9,7 +9,7 @@ debug('Create configuration.')
 const karmaConfig = {
   basePath: '../', // project root in relation to bin/karma.js
   files: [
-    './node_modules/phantomjs-polyfill/bind-polyfill.js',
+    './node_modules/babel-polyfill/dist/polyfill.js',
     {
       pattern: `./${config.dir_test}/test-bundler.js`,
       watched: false,

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
   },
   "devDependencies": {
     "babel-eslint": "^6.0.0-beta.6",
+    "babel-polyfill": "^6.7.4",
     "chai": "^3.4.1",
     "chai-as-promised": "^5.1.0",
     "chai-enzyme": "^0.4.0",
@@ -150,7 +151,6 @@
     "karma-webpack-with-fast-source-maps": "^1.9.2",
     "mocha": "^2.2.5",
     "nodemon": "^1.8.1",
-    "phantomjs-polyfill": "0.0.2",
     "phantomjs-prebuilt": "^2.1.3",
     "react-addons-test-utils": "^0.14.0",
     "react-transform-catch-errors": "^1.0.2",


### PR DESCRIPTION
Phantom doesn't include some new method in ES6. We need to include a polyfill for some of these things in karma.conf file for running test.

Related issue : https://github.com/davezuko/react-redux-starter-kit/issues/697