### PR TITLE
Nitrous.io Quickstart button

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ This starter kit is designed to get you up and running with a bunch of awesome n
 
 The primary goal of this project is to remain as **unopinionated** as possible. Its purpose is not to dictate your project structure or to demonstrate a complete sample application, but to provide a set of tools intended to make front-end development robust, easy, and, most importantly, fun. Check out the full feature list below!
 
+Nitrous Quickstart
+------------------
+
+You can quickly create a free development environment to get started using this
+starter kit in the cloud on [Nitrous](https://www.nitrous.io/):
+
+<a href="https://www.nitrous.io/quickstart">
+  <img src="https://nitrous-image-icons.s3.amazonaws.com/quickstart.png" alt="Nitrous Quickstart" width=142 height=34>
+</a>
+
+In the IDE, start this starter kit via `Run > Start React Redux Starter Kit` and access your site via `Preview > 3000`.
+
 Table of Contents
 -----------------
 1. [Requirements](#requirements)

--- a/README.nitrous.md
+++ b/README.nitrous.md
@@ -1,0 +1,13 @@
+# Setup
+
+Welcome to your React Redux Starter Kit project on Nitrous.
+
+## Running the development server:
+
+In the [Nitrous IDE](https://community.nitrous.io/docs/ide-overview), start React Redux Starter Kit via "Run > Start React Redux Starter Kit".
+
+Now you've got a development server running and can see the output in the Nitrous terminal window. You can open up a new shell or utilize [tmux](https://community.nitrous.io/docs/tmux) to open new shells to run other commands.
+
+## Preview the app
+
+In the Nitrous IDE, open the "Preview" menu and click "Port 3000".

--- a/nitrous-post-create.sh
+++ b/nitrous-post-create.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+echo 'running npm install - this might take awhile...'
+npm install --no-progress
+echo 'installing Redux CLI...' 
+npm i redux-cli -g --no-progress 
+sed -i 's/server_host : \x27localhost\x27/server_host : \x270.0.0.0\x27/g' config/_base.js 
+sed -i 's/compiler_public_path: `.*`/compiler_public_path: \x27\/\x27/g' config/_development.js

--- a/nitrous.json
+++ b/nitrous.json
@@ -1,0 +1,8 @@
+{
+  "template": "nodejs",
+  "ports": [3000],
+  "name": "A React Redux Starter Kit",
+  "scripts": {
+    "Start React Redux Start Kit": "cd ~/code/react-redux-starter-kit && npm run dev"
+  }
+}


### PR DESCRIPTION
Added Nitrous Quickstart files so anyone can quickly spin up a free, cloud dev environment to start using this repo. Clicking the Quickstart button will automatically clone this repo and will install and configure any required packages.