### PR TITLE
added npm script to lint during development (live linting)

### DIFF
--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -96,21 +96,21 @@ times for larger projects. `npm run lint` still exists to aid in
 deploy processes (such as with CI), and it's recommended that you
 use a linting plugin for your IDE in place of this loader.
 
-If you do wish to continue using the loader, you can uncomment
-the code below and run `npm i --save-dev eslint-loader`. This code
-will be removed in a future release.
-
-webpackConfig.module.preLoaders = [{
-  test: /\.(js|jsx)$/,
-  loader: 'eslint',
-  exclude: /node_modules/
-}]
-
-webpackConfig.eslint = {
-  configFile: paths.base('.eslintrc'),
-  emitWarning: __DEV__
-}
+If you do wish to continue using the loader, you can run
+'npm run dev:lint'.
 */
+if (process.argv.indexOf('eslint') != -1) {
+  webpackConfig.module.preLoaders = [{
+    test: /\.(js|jsx)$/,
+    loader: 'eslint',
+    exclude: /node_modules/
+  }]
+
+  webpackConfig.eslint = {
+    configFile: paths.base('.eslintrc'),
+    emitWarning: __DEV__
+  }
+}
 
 // ------------------------------------
 // Loaders

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint:fix": "npm run lint -- --fix",
     "start": "better-npm-run start",
     "dev": "better-npm-run dev",
+    "dev:lint": "better-npm-run dev:lint",
     "dev:nw": "npm run dev -- --nw",
     "dev:no-debug": "npm run dev -- --no_debug",
     "test": "better-npm-run test",
@@ -33,6 +34,13 @@
     },
     "dev": {
       "command": "nodemon --exec babel-node bin/server",
+      "env": {
+        "NODE_ENV": "development",
+        "DEBUG": "app:*"
+      }
+    },
+    "dev:lint": {
+      "command": "nodemon --exec babel-node bin/server eslint",
       "env": {
         "NODE_ENV": "development",
         "DEBUG": "app:*"
@@ -134,6 +142,7 @@
     "eslint": "^2.4.0",
     "eslint-config-standard": "^5.1.0",
     "eslint-config-standard-react": "^2.2.0",
+    "eslint-loader": "^1.3.0",
     "eslint-plugin-babel": "^3.0.0",
     "eslint-plugin-flow-vars": "^0.3.0",
     "eslint-plugin-promise": "^1.0.8",


### PR DESCRIPTION
For some of us not running monolithic React apps and using this boilerplate, we would like to keep the option to run eslint during live reloads. It's optional and added as a separate script, if desired :)