### PR TITLE
Adding this will not show those annoying npm errors at the end after linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "clean": "rimraf dist",
     "compile": "better-npm-run compile",
-    "lint": "eslint .",
+    "lint": "eslint . || true",
     "lint:fix": "npm run lint -- --fix",
     "start": "better-npm-run start",
     "dev": "better-npm-run dev",


### PR DESCRIPTION
adding the || true after the eslint . will not show the npm errors at the end and keep them silent. It's annoying to see in my opinion. :)