### PR TITLE
style: add space before render method

### DIFF
--- a/blueprints/smart/files/__root__/containers/__name__.js
+++ b/blueprints/smart/files/__root__/containers/__name__.js
@@ -8,7 +8,7 @@ type Props = {
 export class <%= pascalEntityName %> extends React.Component {
   props: Props;
 
-  render() {
+  render () {
     return (
       <div></div>
     )


### PR DESCRIPTION
Linter generates errors Missing space bofore function parentheses when generating smart component. Added space before render method to make linter happy. Other files should be fine.