### PR TITLE
Remove `interfaces` application structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ The application structure presented in this boilerplate is **fractal**, where fu
 ├── build                    # All build-related configuration
 │   └── webpack              # Environment-specific configuration files for webpack
 ├── config                   # Project configuration settings
-├── interfaces               # Type declarations for Flow
 ├── server                   # Koa application (uses webpack middleware)
 │   └── main.js              # Server application entry point
 ├── src                      # Application source code


### PR DESCRIPTION
Since Flow has been removed from the project, we should update application structure to not include interfaces #790