### PR TITLE
fix(typo): remove end parens from test description

### DIFF
--- a/tests/components/Header/Header.spec.js
+++ b/tests/components/Header/Header.spec.js
@@ -22,7 +22,7 @@ describe('(Component) Header', () => {
       expect(_wrapper.contains(<IndexLink to='/'/>)).to.equal.true
     })
 
-    it('Should render an Link to Counter route)', () => {
+    it('Should render an Link to Counter route', () => {
       expect(_wrapper.contains(<Link to='/counter'/>)).to.equal.true
     })
 


### PR DESCRIPTION
Just happened to notice this extra ')' at the end of the test description as I was starting a new project today. Thought I'd fix it.

Thanks for all the hard work on this project!