### PR TITLE
koa-static 3.x now supports koa2, so we don't need to convert anymore

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "koa-connect-history-api-fallback": "^0.3.0",
     "koa-convert": "^1.2.0",
     "koa-proxy": "^0.6.0",
-    "koa-static": "^2.0.0",
+    "koa-static": "^3.0.0",
     "node-sass": "^3.7.0",
     "normalize.css": "^4.1.1",
     "postcss-loader": "^0.9.0",

--- a/server/main.js
+++ b/server/main.js
@@ -42,7 +42,7 @@ if (config.env === 'development') {
   // these files. This middleware doesn't need to be enabled outside
   // of development since this directory will be copied into ~/dist
   // when the application is compiled.
-  app.use(convert(serve(paths.client('static'))))
+  app.use(serve(paths.client('static')))
 } else {
   debug(
     'Server is being run outside of live development mode, meaning it will ' +
@@ -55,7 +55,7 @@ if (config.env === 'development') {
   // Serving ~/dist by default. Ideally these files should be served by
   // the web server and not the app server, but this helps to demo the
   // server in production.
-  app.use(convert(serve(paths.dist())))
+  app.use(serve(paths.dist()))
 }
 
 export default app


### PR DESCRIPTION
Fix #864