### PR TITLE
Upgrade/redbox react 1.2.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "nodemon": "^1.8.1",
     "phantomjs-prebuilt": "^2.1.3",
     "react-addons-test-utils": "^15.0.0",
-    "redbox-react": "^1.2.2",
+    "redbox-react": "^1.2.10",
     "sinon": "^1.17.3",
     "sinon-chai": "^2.8.0",
     "webpack-dev-middleware": "^1.6.1",

--- a/src/main.js
+++ b/src/main.js
@@ -59,7 +59,7 @@ let render = (routerKey = null) => {
 if (__DEV__ && module.hot) {
   const renderApp = render
   const renderError = (error) => {
-    const RedBox = require('redbox-react')
+    const RedBox = require('redbox-react').default
 
     ReactDOM.render(<RedBox error={error} />, MOUNT_NODE)
   }


### PR DESCRIPTION
This version of `redbox-react` fixes a bug that was throwing an error every time the error screen was unmounted. Related to #896.