### PR TITLE
Fix(karma): Fix Proper incremental test running.

### DIFF
--- a/build/karma.conf.js
+++ b/build/karma.conf.js
@@ -68,7 +68,7 @@ if (config.globals.__COVERAGE__) {
     test: /\.(js|jsx)$/,
     include: new RegExp(config.dir_client),
     loader: 'isparta',
-    exclude: /node_modules/
+    exclude: [/node_modules/, /test-bundler/]
   }]
 }
 

--- a/tests/test-bundler.js
+++ b/tests/test-bundler.js
@@ -21,10 +21,9 @@ global.should = chai.should()
 // Require Tests
 // ---------------------------------------
 // for use with karma-webpack-with-fast-source-maps
-// NOTE: `new Array()` is used rather than an array literal since
-// for some reason an array literal without a trailing `;` causes
-// some build environments to fail.
-const __karmaWebpackManifest__ = new Array() // eslint-disable-line
+// NOTE: A trailing `;` is used because its absense breaks some test environments
+// `new Array()` breaks the `__karmaWebpackManifest__` variable. 
+const __karmaWebpackManifest__ = []; // eslint-disable-line
 const inManifest = (path) => ~__karmaWebpackManifest__.indexOf(path)
 
 // require all `tests/**/*.spec.js`

--- a/tests/test-bundler.js
+++ b/tests/test-bundler.js
@@ -21,9 +21,7 @@ global.should = chai.should()
 // Require Tests
 // ---------------------------------------
 // for use with karma-webpack-with-fast-source-maps
-// NOTE: A trailing `;` is used because its absense breaks some test environments
-// `new Array()` breaks the `__karmaWebpackManifest__` variable. 
-const __karmaWebpackManifest__ = []; // eslint-disable-line
+const __karmaWebpackManifest__ = []
 const inManifest = (path) => ~__karmaWebpackManifest__.indexOf(path)
 
 // require all `tests/**/*.spec.js`


### PR DESCRIPTION
Resolves #871 

Declaring `__karmaWebpackManifest__` as a `new Arrray()` breaks incremental the incremental test runner. As it prevents `__karmaWebpackManifest__` from updating with as the webpack manifest changes. 

The ugly fast fix is to use an array literal and terminate the statement with a ';' to avoid regressing #709 