### PR TITLE
feat(redux): Add createReducer Abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,10 @@ The application structure presented in this boilerplate is **fractal**, where fu
 │   ├── store                # Redux-specific pieces
 │   │   ├── createStore.js   # Create and instrument redux store
 │   │   └── reducers.js      # Reducer registry and injection
-│   └── styles               # Application-wide styles (generally settings)
+│   ├── styles               # Application-wide styles (generally settings)
+│   └── utils                # Application-wide utility functions
+│       ├── createReducer.js # Helper to create reducer from an object
+│       └── index.js         # General utils access point
 └── tests                    # Unit tests
 ```
 

--- a/blueprints/route/files/src/routes/__name__/modules/__name__.js
+++ b/blueprints/route/files/src/routes/__name__/modules/__name__.js
@@ -1,3 +1,4 @@
+import { createReducer } from 'utils'
 // ------------------------------------
 // Constants
 // ------------------------------------
@@ -48,8 +49,4 @@ const ACTION_HANDLERS = {
 // Reducer
 // ------------------------------------
 const initialState = 0
-export default function counterReducer (state = initialState, action) {
-  const handler = ACTION_HANDLERS[action.type]
-
-  return handler ? handler(state, action) : state
-}
+export default createReducer(initialState, ACTION_HANDLERS)

--- a/src/routes/Counter/modules/counter.js
+++ b/src/routes/Counter/modules/counter.js
@@ -1,3 +1,5 @@
+import { createReducer } from 'utils'
+
 // ------------------------------------
 // Constants
 // ------------------------------------
@@ -48,8 +50,4 @@ const ACTION_HANDLERS = {
 // Reducer
 // ------------------------------------
 const initialState = 0
-export default function counterReducer (state = initialState, action) {
-  const handler = ACTION_HANDLERS[action.type]
-
-  return handler ? handler(state, action) : state
-}
+export default createReducer(initialState, ACTION_HANDLERS)

--- a/src/utils/createReducer.js
+++ b/src/utils/createReducer.js
@@ -1,0 +1,10 @@
+/*  Creates a reducer from an object of action handlers. See:
+    http://redux.js.org/docs/recipes/ReducingBoilerplate.html#reducers */
+
+export default function createReducer (initialState, actionHandlers) {
+  return (state = initialState, action) => {
+    const handler = actionHandlers[action.type]
+
+    return handler ? handler(state, action) : state
+  }
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,3 @@
+import createReducer from './createReducer'
+
+export { createReducer }

--- a/tests/utils/createReducer.spec.js
+++ b/tests/utils/createReducer.spec.js
@@ -1,0 +1,43 @@
+import * as sinon from 'sinon'
+import { createReducer } from 'utils'
+
+describe('utils', () => {
+  let presentSpy
+  const initialState = { initial: 'state' }
+  const presentAction = { type: 'PRESENT' }
+  const newState = 'new state'
+
+  beforeEach(() => {
+    presentSpy = sinon.spy((state, action) => newState)
+  })
+
+  it('should return a function', () => {
+    expect(createReducer()).to.be.a('function')
+  })
+
+  it('should return an initial state if there is no matching action on handlers', () => {
+    const actionHandlers = { PRESENT: presentSpy }
+    expect(createReducer(initialState, actionHandlers)(undefined, { type: 'NOT_PRESENT' }))
+      .to.deep.equal(initialState)
+    expect(presentSpy).not.to.have.been.called
+  })
+
+  it('should call the handler located under the key at action.type', () => {
+    const actionHandlers = { PRESENT: presentSpy }
+    expect(createReducer(initialState, actionHandlers)(undefined, presentAction))
+      .to.deep.equal(newState)
+    expect(presentSpy).to.have.been.calledOnce
+      .and.to.have.been.calledWith(initialState, presentAction)
+  })
+
+  it('should call the handler with updated state if it has already been called once', () => {
+    const actionHandlers = { PRESENT: presentSpy }
+    const reducer = createReducer(initialState, actionHandlers)
+    const firstState = reducer(undefined, presentAction)
+    reducer(firstState, presentAction)
+    expect(presentSpy).to.have.been.calledTwice
+      .and.to.have.been.calledWith(initialState, presentAction)
+      .and.to.have.been.calledWith(newState, presentAction)
+  })
+})
+


### PR DESCRIPTION
Pr adds an abstraction for the pattern of creating a reducer from an object where the key corresponds to an action type.

[Issue #976](https://github.com/davezuko/react-redux-starter-kit/issues/976)

