### PR TITLE
fix(compile): report errors in webpack compilation

### DIFF
--- a/build/webpack-compiler.js
+++ b/build/webpack-compiler.js
@@ -10,15 +10,16 @@ export default function webpackCompiler (webpackConfig, statsFormat = DEFAULT_ST
     const compiler = webpack(webpackConfig)
 
     compiler.run((err, stats) => {
-      const jsonStats = stats.toJson()
-
-      debug('Webpack compile completed.')
-      debug(stats.toString(statsFormat))
-
       if (err) {
         debug('Webpack compiler encountered a fatal error.', err)
         return reject(err)
-      } else if (jsonStats.errors.length > 0) {
+      }
+
+      const jsonStats = stats.toJson()
+      debug('Webpack compile completed.')
+      debug(stats.toString(statsFormat))
+
+      if (jsonStats.errors.length > 0) {
         debug('Webpack compiler encountered errors.')
         debug(jsonStats.errors.join('\n'))
         return reject(new Error('Webpack compiler encountered errors'))
@@ -32,4 +33,3 @@ export default function webpackCompiler (webpackConfig, statsFormat = DEFAULT_ST
     })
   })
 }
-


### PR DESCRIPTION
Errors in configuration were getting swallowed and reporting `TypeError: Cannot read property 'toJson' of undefined` instead of the actual root cause.  This is because there is an attempt to read the `stats` object (undefined in the case of a compile error) before checking the `err` object