### PR TITLE
style(eslint): Enforce linting on all code

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,5 +2,4 @@ blueprints/**/files/**
 coverage/**
 node_modules/**
 dist/**
-*.spec.js
 src/index.html

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "clean": "rimraf dist",
     "compile": "better-npm-run compile",
-    "lint": "eslint src tests server",
+    "lint": "eslint bin build config server src tests",
     "lint:fix": "npm run lint -- --fix",
     "start": "better-npm-run start",
     "dev": "better-npm-run dev",

--- a/tests/components/Counter/Counter.spec.js
+++ b/tests/components/Counter/Counter.spec.js
@@ -54,7 +54,7 @@ describe('(Component) Counter', () => {
 
       _spies.dispatch.should.have.been.called
       _spies.increment.should.have.been.called
-    });
+    })
   })
 
   describe('A Double (Async) button...', () => {
@@ -75,6 +75,6 @@ describe('(Component) Counter', () => {
 
       _spies.dispatch.should.have.been.called
       _spies.doubleAsync.should.have.been.called
-    });
+    })
   })
 })

--- a/tests/components/Header/Header.spec.js
+++ b/tests/components/Header/Header.spec.js
@@ -8,7 +8,7 @@ describe('(Component) Header', () => {
   let _wrapper
 
   beforeEach(() => {
-    _wrapper = shallow(<Header/>)
+    _wrapper = shallow(<Header />)
   })
 
   it('Renders a welcome message', () => {
@@ -18,7 +18,6 @@ describe('(Component) Header', () => {
   })
 
   describe('Navigation links...', () => {
-
     it('Should render a Link to Home route', () => {
       expect(_wrapper.contains(
         <IndexLink activeClassName={classes.activeRoute} to='/'>

--- a/tests/framework.spec.js
+++ b/tests/framework.spec.js
@@ -23,8 +23,8 @@ describe('(Framework) Karma Plugins', function () {
   })
 
   it('Should have chai-as-promised helpers.', function () {
-    const pass = new Promise(res => res('test'))
-    const fail = new Promise((res, rej) => rej())
+    const pass = new Promise(resolve => resolve('test'))
+    const fail = new Promise((resolve, reject) => reject())
 
     return Promise.all([
       expect(pass).to.be.fulfilled,
@@ -32,7 +32,7 @@ describe('(Framework) Karma Plugins', function () {
     ])
   })
 
-  it('should have chai-enzyme working', function() {
+  it('should have chai-enzyme working', function () {
     let wrapper = shallow(<Fixture />)
     expect(wrapper.find('#checked')).to.be.checked()
 

--- a/tests/routes/Counter/index.spec.js
+++ b/tests/routes/Counter/index.spec.js
@@ -8,11 +8,10 @@ describe('(Route) Counter', () => {
   })
 
   it('Should return a route configuration object', () => {
-    expect(typeof(_route)).to.equal('object')
+    expect(typeof _route).to.equal('object')
   })
 
   it('Configuration should contain path `counter`', () => {
     expect(_route.path).to.equal('counter')
   })
-
 })

--- a/tests/routes/Home/components/HomeView.spec.js
+++ b/tests/routes/Home/components/HomeView.spec.js
@@ -20,5 +20,4 @@ describe('(View) Home', () => {
     expect(duck).to.exist
     expect(duck.attr('alt')).to.match(/This is a duck, because Redux!/)
   })
-
 })

--- a/tests/routes/Home/index.spec.js
+++ b/tests/routes/Home/index.spec.js
@@ -8,7 +8,7 @@ describe('(Route) Home', () => {
   })
 
   it('Should return a route configuration object', () => {
-    expect(typeof(HomeRoute)).to.equal('object')
+    expect(typeof HomeRoute).to.equal('object')
   })
 
   it('Should define a route component', () => {


### PR DESCRIPTION
I cannot think of a good reason why all code shouldn't come under the same linting rules, so this expands `npm run lint` to cover all major files, including tests.