### PR TITLE
fix(nodemon): nodemon mustn't exec node to start the server

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
       }
     },
     "dev": {
-      "command": "nodemon --exec node bin/server --ignore dist --ignore coverage --ignore tests --ignore src",
+      "command": "nodemon bin/server --ignore dist --ignore coverage --ignore tests --ignore src",
       "env": {
         "NODE_ENV": "development",
         "DEBUG": "app:*"


### PR DESCRIPTION
The command `nodemon --exec node bin/server` does not start the server. Instead it shows the wrong usage of the `nodemon` command. Moreover, nodemon is a node wrapper, so it's not needed to call node as external program.