### PR TITLE
fix(home component): remove implied use of CSS modules (deprecated)

### DIFF
--- a/src/routes/Home/components/HomeView.js
+++ b/src/routes/Home/components/HomeView.js
@@ -1,13 +1,13 @@
 import React from 'react'
 import DuckImage from '../assets/Duck.jpg'
-import classes from './HomeView.scss'
+import './HomeView.scss'
 
 export const HomeView = () => (
   <div>
     <h4>Welcome!</h4>
     <img
       alt='This is a duck, because Redux!'
-      className={classes.duck}
+      className='duck'
       src={DuckImage} />
   </div>
 )


### PR DESCRIPTION
Awesome starter kit..love the structure!  This tripped me up a bit at first, because I assumed CSS modules were being used..it looks like you just had some remnants of its use before it was deprecated from the webpack config.