### PR TITLE
refactor(standard): make use of resolve root

### DIFF
--- a/src/layouts/CoreLayout/CoreLayout.js
+++ b/src/layouts/CoreLayout/CoreLayout.js
@@ -1,7 +1,7 @@
 import React from 'react'
-import Header from '../../components/Header'
+import Header from 'components/Header'
 import './CoreLayout.scss'
-import '../../styles/core.scss'
+import 'styles/core.scss'
 
 export const CoreLayout = ({ children }) => (
   <div className='container text-center'>

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import createStore from './store/createStore'
-import AppContainer from './containers/AppContainer'
+import createStore from 'store/createStore'
+import AppContainer from 'containers/AppContainer'
 
 // ========================================================
 // Store Instantiation

--- a/src/routes/Counter/index.js
+++ b/src/routes/Counter/index.js
@@ -1,4 +1,4 @@
-import { injectReducer } from '../../store/reducers'
+import { injectReducer } from 'store/reducers'
 
 export default (store) => ({
   path : 'counter',

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,5 +1,5 @@
 // We only need to import the modules necessary for initial render
-import CoreLayout from '../layouts/CoreLayout/CoreLayout'
+import CoreLayout from 'layouts/CoreLayout'
 import Home from './Home'
 import CounterRoute from './Counter'
 


### PR DESCRIPTION
It is stated in the README to import modules like so

    import foo from 'components/foo'

But doesn't utilize in the code. I don't know if there is a particular reason why not, so I've created this PR