### PR TITLE
feat(core) add support for specifying environment context from command line

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,7 +16,8 @@
     "__DEV__"      : false,
     "__TEST__"     : false,
     "__PROD__"     : false,
-    "__COVERAGE__" : false
+    "__COVERAGE__" : false,
+    "__CONTEXT__"  : false
   },
   "rules": {
     "key-spacing"          : 0,

--- a/config/environments.js
+++ b/config/environments.js
@@ -13,6 +13,14 @@ module.exports = {
   }),
 
   // ======================================================
+  // Overrides when NODE_ENV === 'development' and context === 'qa'
+  // ======================================================
+  development_qa : (config) => ({
+    server_port: 3001,
+    compiler_public_path : `http://${config.server_host}:3001/`
+  }),
+
+  // ======================================================
   // Overrides when NODE_ENV === 'production'
   // ======================================================
   production : (config) => ({
@@ -25,5 +33,13 @@ module.exports = {
       chunkModules : true,
       colors       : true
     }
+  }),
+
+  // ======================================================
+  // Overrides when NODE_ENV === 'production' and context === 'qa'
+  // ======================================================
+  production_qa : (config) => ({
+    server_port: 3001,
+    compiler_public_path     : './'
   })
 }

--- a/config/index.js
+++ b/config/index.js
@@ -10,6 +10,7 @@ debug('Creating default configuration.')
 // ========================================================
 const config = {
   env : process.env.NODE_ENV || 'development',
+  env_context: argv.env_context || false,
 
   // ----------------------------------
   // Project Structure
@@ -78,6 +79,7 @@ config.globals = {
     'NODE_ENV' : JSON.stringify(config.env)
   },
   'NODE_ENV'     : config.env,
+  '__CONTEXT__'  : JSON.stringify(config.env_context),
   '__DEV__'      : config.env === 'development',
   '__PROD__'     : config.env === 'production',
   '__TEST__'     : config.env === 'test',
@@ -126,6 +128,16 @@ if (overrides) {
   Object.assign(config, overrides(config))
 } else {
   debug('No environment overrides found, defaults will be used.')
+}
+
+// ========================================================
+// Context Configuration
+// ========================================================
+const context = config.env + '_' + config.env_context
+const contextOverrides = environments[context]
+if (contextOverrides) {
+  debug(`Found context overrides for "${context}", applying.`)
+  Object.assign(config, contextOverrides(config))
 }
 
 module.exports = config

--- a/package.json
+++ b/package.json
@@ -14,11 +14,13 @@
     "lint:fix": "npm run lint -- --fix",
     "start": "better-npm-run start",
     "dev": "better-npm-run dev",
+    "dev:qa": "better-npm-run dev --env_context=qa",
     "test": "better-npm-run test",
     "test:dev": "npm run test -- --watch",
     "deploy": "better-npm-run deploy",
     "deploy:dev": "better-npm-run deploy:dev",
     "deploy:prod": "better-npm-run deploy:prod",
+    "deploy:prod:qa": "better-npm-run deploy:prod -- -- --env_context=qa",
     "codecov": "cat coverage/*/lcov.info | codecov"
   },
   "betterScripts": {


### PR DESCRIPTION
We are running our app in multiple environments (qa, sandbox...) and we were looking for a scalable way to provide different configuration to them. So this PR introduces `env_context` command line argument for picking up additional config override and global `__CONTEXT__`  variable to switch login within application.

`config\environments.js` and `package.json` are included only as an example