### PR TITLE
<fix>(webpack) Throw compliation errors

### DIFF
--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -43,9 +43,33 @@ webpackConfig.output = {
 }
 
 // ------------------------------------
+// Externals
+// ------------------------------------
+webpackConfig.externals = {}
+webpackConfig.externals['react/lib/ExecutionEnvironment'] = true
+webpackConfig.externals['react/lib/ReactContext'] = true
+webpackConfig.externals['react/addons'] = true
+
+// ------------------------------------
 // Plugins
 // ------------------------------------
 webpackConfig.plugins = [
+  // Plugin to show any webpack warnings and prevent tests from running
+  function () {
+    let errors = []
+    this.plugin('done', function (stats) {
+      if (stats.compilation.errors.length) {
+        // Log each of the warnings
+        stats.compilation.errors.forEach(function (error) {
+          errors.push(error.message || error)
+        })
+
+        // Pretend no assets were generated. This prevents the tests
+        // from running making it clear that there were warnings.
+        throw new Error(errors)
+      }
+    })
+  },
   new webpack.DefinePlugin(config.globals),
   new HtmlWebpackPlugin({
     template : paths.client('index.html'),


### PR DESCRIPTION
This PR corrects #863 where if a syntax error is encountered in tests,
the process throws an error during compilation. Tests are never run and
CI builds should now fail if there are syntax errors. This is done by
adding a small webpack plugin that checks for errors during compilation,
and adds them to an array of errors. This array is then thrown but only
if there are errors during the compilation stage.

Based on the suggestions from:
https://gist.github.com/Stuk/6b574049435df532e905
