### PR TITLE
docs(readme): remove blueprint from application structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ The application structure presented in this boilerplate is **fractal**, where fu
 ```
 .
 ├── bin                      # Build/Start scripts
-├── blueprints               # Blueprint files for redux-cli
 ├── build                    # All build-related configuration
 │   └── webpack              # Environment-specific configuration files for webpack
 ├── config                   # Project configuration settings


### PR DESCRIPTION
blueprint was deprecated in [this commit](https://github.com/davezuko/react-redux-starter-kit/commit/b2756be3fd0a96d3ff0f689689969cd4273246a3).
