### PR TITLE
chore(reduxDevTool): update reduxDevTools to use new api

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -27,8 +27,8 @@ let render = () => {
 // Developer Tools Setup
 // ========================================================
 if (__DEV__) {
-  if (window.devToolsExtension) {
-    window.devToolsExtension.open()
+  if (window.__REDUX_DEVTOOLS_EXTENSION__) {
+    window.__REDUX_DEVTOOLS_EXTENSION__.open()
   }
 }
 

--- a/src/store/createStore.js
+++ b/src/store/createStore.js
@@ -14,10 +14,13 @@ export default (initialState = {}) => {
   // Store Enhancers
   // ======================================================
   const enhancers = []
+
+  let composeEnhancers = compose
+
   if (__DEV__) {
-    const devToolsExtension = window.devToolsExtension
-    if (typeof devToolsExtension === 'function') {
-      enhancers.push(devToolsExtension())
+    const composeWithDevToolsExtension = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
+    if (typeof composeWithDevToolsExtension === 'function') {
+      composeEnhancers = composeWithDevToolsExtension
     }
   }
 
@@ -27,7 +30,7 @@ export default (initialState = {}) => {
   const store = createStore(
     makeRootReducer(),
     initialState,
-    compose(
+    composeEnhancers(
       applyMiddleware(...middleware),
       ...enhancers
     )


### PR DESCRIPTION
`window.devToolsExtension` is deprecated in favor of `window.__REDUX_DEVTOOLS_EXTENSION__` and `window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__`.
See: zalmoxisus/redux-devtools-extension#220
