### PR TITLE
Fixed issue 'Unexpected key counter found in previous state received …

### DIFF
--- a/src/store/createStore.js
+++ b/src/store/createStore.js
@@ -25,7 +25,7 @@ export default (initialState = {}) => {
   // Store Instantiation and HMR Setup
   // ======================================================
   const store = createStore(
-    makeRootReducer(),
+    makeRootReducer({}, initialState),
     initialState,
     compose(
       applyMiddleware(...middleware),

--- a/src/store/reducers.js
+++ b/src/store/reducers.js
@@ -1,10 +1,19 @@
 import { combineReducers } from 'redux'
 import locationReducer from './location'
 
-export const makeRootReducer = (asyncReducers) => {
+export const makeRootReducer = (asyncReducers, initialState) => {
+  let missingReducers = { }
+  if (initialState !== undefined && typeof initialState === 'object') {
+    for (let key in initialState) {
+      if (!asyncReducers.hasOwnProperty(key)) {
+        missingReducers[key] = () => initialState[key]
+      }
+    }
+  }
   return combineReducers({
     location: locationReducer,
-    ...asyncReducers
+    ...asyncReducers,
+    ...missingReducers
   })
 }
 


### PR DESCRIPTION
…by the reducer' when added window.__INITIAL_STATE of { counter: 1 }. The counter reducer is async injected, so there no reducer to key 'counter' when combineReducers in createStore intially. Therefore a warning from combineReducers shows in non-production mode, but the initial state of { counter: 1 } is removed in production mode