### PR TITLE
Exclude /node_modules/ from webpack in karma config to eliminate erro…

### DIFF
--- a/build/karma.conf.js
+++ b/build/karma.conf.js
@@ -62,6 +62,7 @@ if (config.globals.__COVERAGE__) {
   karmaConfig.webpack.module.preLoaders = [{
     test    : /\.(js|jsx)$/,
     include : new RegExp(config.dir_client),
+    exclude : /node_modules/,
     loader  : 'babel',
     query   : Object.assign({}, config.compiler_babel, {
       plugins : (config.compiler_babel.plugins || []).concat('istanbul')


### PR DESCRIPTION
…rs when running tests on linux. For some reason karma with webpack on linux behaves differently (than macOS) when traversing packages during testing. On linux (tested with Ubuntu 14) it generates errors from dependencies of dependencies. Adding an exclude property of the webpack config within the karma config prevents the transversal that causes the errors. After adding this exclude, both linux and macOS behave the same. An issue with some related notes can be found here: https://github.com/davezuko/react-redux-starter-kit/issues/1037
