### PR TITLE
Changed import of CoreLayout in route index

### DIFF
--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,5 +1,5 @@
 // We only need to import the modules necessary for initial render
-import CoreLayout from '../layouts/CoreLayout/CoreLayout'
+import CoreLayout from '../layouts/CoreLayout'
 import Home from './Home'
 import CounterRoute from './Counter'
 


### PR DESCRIPTION
The point of CoreLayout/index.js is to import it instead of CoreLayout.js right?  It is CoreLayout.js's container.