### PR TITLE
Use export from rather than import and export

### DIFF
--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -1,3 +1,1 @@
-import Header from './Header'
-
-export default Header
+export Header from './Header'

--- a/src/layouts/CoreLayout/index.js
+++ b/src/layouts/CoreLayout/index.js
@@ -1,3 +1,1 @@
-import CoreLayout from './CoreLayout'
-
-export default CoreLayout
+export CoreLayout from './CoreLayout'


### PR DESCRIPTION
This is a pretty minor improvement, but I thought it might help since it's likely many folks will be reusing/copying this pattern. Instead of doing an `import` and `export`, why not shorten it to just `export from`.