### PR TITLE
#1207 fix(Config,Babel): Redbox error source mapping change

### DIFF
--- a/config/project.config.js
+++ b/config/project.config.js
@@ -32,10 +32,10 @@ const config = {
   // ----------------------------------
   compiler_babel : {
     cacheDirectory : true,
-    plugins        : ['transform-runtime'],
+    plugins        : ['transform-react-display-name', 'transform-runtime'],
     presets        : ['es2015', 'react', 'stage-0']
   },
-  compiler_devtool         : 'source-map',
+  compiler_devtool         : 'eval',
   compiler_hash_type       : 'hash',
   compiler_fail_on_warning : false,
   compiler_quiet           : false,

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
   "devDependencies": {
     "babel-eslint": "^7.1.0",
     "babel-plugin-istanbul": "^3.0.0",
+    "babel-plugin-transform-react-display-name": "^6.23.0",
     "chai": "^3.4.1",
     "chai-as-promised": "^6.0.0",
     "chai-enzyme": "^0.6.1",


### PR DESCRIPTION
RedBox showing error links to compile code instead of original code from webpack #1207 