### PR TITLE
Use prop-types npm module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-redux-starter-kit",
-  "version": "3.0.0-alpha.2",
+  "version": "3.0.0-alpha.3",
   "description": "Get started with React, Redux, and React-Router!",
   "main": "index.js",
   "engines": {
@@ -98,6 +98,7 @@
     "node-sass": "^4.0.0",
     "normalize.css": "^5.0.0",
     "postcss-loader": "^1.1.0",
+    "prop-types": "^15.5.6",
     "react": "^15.0.0",
     "react-dom": "^15.0.0",
     "react-redux": "^5.0.1",

--- a/src/containers/AppContainer.js
+++ b/src/containers/AppContainer.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import { browserHistory, Router } from 'react-router'
 import { Provider } from 'react-redux'
 

--- a/src/layouts/CoreLayout/CoreLayout.js
+++ b/src/layouts/CoreLayout/CoreLayout.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import Header from '../../components/Header'
 import './CoreLayout.scss'
 import '../../styles/core.scss'
@@ -13,7 +14,7 @@ export const CoreLayout = ({ children }) => (
 )
 
 CoreLayout.propTypes = {
-  children : React.PropTypes.element.isRequired
+  children : PropTypes.element.isRequired
 }
 
 export default CoreLayout

--- a/src/routes/Counter/components/Counter.js
+++ b/src/routes/Counter/components/Counter.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 export const Counter = (props) => (
   <div style={{ margin: '0 auto' }} >
@@ -14,9 +15,9 @@ export const Counter = (props) => (
 )
 
 Counter.propTypes = {
-  counter     : React.PropTypes.number.isRequired,
-  doubleAsync : React.PropTypes.func.isRequired,
-  increment   : React.PropTypes.func.isRequired
+  counter     : PropTypes.number.isRequired,
+  doubleAsync : PropTypes.func.isRequired,
+  increment   : PropTypes.func.isRequired
 }
 
 export default Counter


### PR DESCRIPTION
Addresses API changes in latest React API, where `PropTypes is deprecated.
https://github.com/facebook/react/blob/master/CHANGELOG.md#1550-april-7-2017

and fixes: https://github.com/davezuko/react-redux-starter-kit/issues/1216