### PR TITLE
Auto-open browser when running in dev mode

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -5,6 +5,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin')
 const ExtractTextPlugin = require('extract-text-webpack-plugin')
 const project = require('./project.config')
 const debug = require('debug')('app:config:webpack')
+const OpenBrowserPlugin = require('open-browser-webpack-plugin')
 
 const __DEV__ = project.globals.__DEV__
 const __PROD__ = project.globals.__PROD__
@@ -87,7 +88,8 @@ if (__DEV__) {
   debug('Enabling plugins for live development (HMR, NoErrors).')
   webpackConfig.plugins.push(
     new webpack.HotModuleReplacementPlugin(),
-    new webpack.NoErrorsPlugin()
+    new webpack.NoErrorsPlugin(),
+    new OpenBrowserPlugin({ url: project.compiler_public_path })
   )
 } else if (__PROD__) {
   debug('Enabling plugins for production (OccurrenceOrder, Dedupe & UglifyJS).')

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "karma-webpack-with-fast-source-maps": "^1.9.2",
     "mocha": "^3.0.1",
     "nodemon": "^1.10.2",
+    "open-browser-webpack-plugin": "0.0.5",
     "phantomjs-prebuilt": "^2.1.12",
     "react-addons-test-utils": "^15.0.0",
     "redbox-react": "^1.2.10",


### PR DESCRIPTION
Using the open-browser-webpack-plugin to auto-open the browser when running “npm run dev”.