### PR TITLE
Upgraded webpack to 1.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "imports-loader": "^0.7.0",
     "ip": "^1.1.2",
     "json-loader": "^0.5.4",
-    "node-sass": "^4.0.0",
+    "node-sass": "^4.5.2",
     "normalize.css": "^5.0.0",
     "postcss-loader": "^1.1.0",
     "prop-types": "^15.5.6",
@@ -109,7 +109,7 @@
     "sass-loader": "^4.0.0",
     "style-loader": "^0.13.1",
     "url-loader": "^0.5.6",
-    "webpack": "^1.12.14",
+    "webpack": "^1.15.0",
     "yargs": "^6.3.0"
   },
   "devDependencies": {
@@ -140,8 +140,12 @@
     "phantomjs-prebuilt": "^2.1.12",
     "react-addons-test-utils": "^15.0.0",
     "redbox-react": "^1.2.10",
+    "redux-devtools": "^3.4.0",
+    "redux-devtools-dock-monitor": "^1.1.2",
+    "redux-devtools-log-monitor": "^1.3.0",
     "sinon": "^1.17.5",
     "sinon-chai": "^2.8.0",
+    "webpack": "^1.15.0",
     "webpack-dev-middleware": "^1.6.1",
     "webpack-hot-middleware": "^2.12.2"
   }


### PR DESCRIPTION
Upgraded webpack to 1.15.0 due to the ENOENT error I got on initial installation/start of application: https://github.com/davezuko/react-redux-starter-kit/issues/1197#issuecomment-301264325