### PR TITLE
expose babel-env targets in project.config.js for easier configuration

### DIFF
--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -78,9 +78,7 @@ config.module.rules.push({
         'babel-preset-react',
         ['babel-preset-env', {
           modules: false,
-          targets: {
-            ie9: true,
-          },
+          targets: project.targetEnvironments,
           uglify: true,
         }],
       ]

--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -78,8 +78,7 @@ config.module.rules.push({
         'babel-preset-react',
         ['babel-preset-env', {
           modules: false,
-          targets: project.targetEnvironments,
-          uglify: true,
+          targets: Object.assign({}, project.targetEnvironments, { uglify: true }),
         }],
       ]
     },

--- a/project.config.js
+++ b/project.config.js
@@ -19,6 +19,10 @@ module.exports = {
   externals: {},
   /** A hash map of variables and their values to expose globally */
   globals: {},
+  /** hashmap of target environments the code must run in (see https://github.com/babel/babel-preset-env#targets */
+  targetEnvironments: {
+    ie9: true,
+  },
   /** Whether to enable verbose logging */
   verbose: false,
   /** The list of modules to bundle separately from the core application code */


### PR DESCRIPTION
Also, moves `uglify` option back inside `targets` where it belongs.  Without this, Uglify fails if you set targets to something more recent than ie9.