### PR TITLE
Fix Webpack build for published packages, puny refactor

### DIFF
--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -51,7 +51,10 @@ const config = {
 // ------------------------------------
 config.module.rules.push({
   test: /\.(js|jsx)$/,
-  exclude: /node_modules/,
+  exclude: (absPath) => {
+    const relativePathToBase = path.relative(project.basePath, absPath);
+    return /node_modules/.test(relativePathToBase);    
+  },
   use: [{
     loader: 'babel-loader',
     query: {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "redbox-react": "^1.3.6",
     "redux": "^3.6.0",
     "redux-thunk": "^2.2.0",
+    "rimraf": "^2.6.1",    
     "whatwg-fetch": "^2.0.3"
   },
   "devDependencies": {
@@ -81,7 +82,6 @@
     "phantomjs-prebuilt": "^2.1.14",
     "react-addons-test-utils": "^15.5.1",
     "react-test-renderer": "^15.5.4",
-    "rimraf": "^2.6.1",
     "sass-loader": "^6.0.5",
     "sinon": "^2.2.0",
     "sinon-chai": "^2.10.0",


### PR DESCRIPTION
If you're basing a project upon the starter kit and you publish it to, say, a privately hosted NPM registry, compilation _may_ fail

**if**

the path up to the project, say `/home/proj/starter-kit`, includes `node_modules`, e.g. `/home/proj/node_modules--this-breaks-it/starter-kit`.

This is the case with an NPM registry, where running an `npm i my-project-based-on-this-starter-kit` automatically creates a folder named, how else, `node_modules` and installs the package therein. Thus, the path `<wherever>/node_modules/my-project-based-on-this-starter-kit` cannot compile the project using Webpack.

Narrowing it down to this was, of course, painful. A `compile` would work on the git checkout and fail on the deployed/installed package. An [issue with CreateReactApp](https://github.com/facebookincubator/create-react-app/issues/637#issuecomment-283544055) finally got me on the right path.

[Popular](https://github.com/webpack/webpack/issues/943#issuecomment-93422434) [opinion](https://github.com/webpack/webpack/issues/2031#issuecomment-183378107) from Webpack's creator also semi-demonizes the use of `exclude`. I wanted to try `include: project.basePath` but that did not work. /cc @davezuko Any ideas here?

If going forward with the `include` fix, one would have to expand the readme and mention the fact that only `appDir` sources are compiled and one has to explicitly specify other paths if one needs to compile other non-`src` sources.

Here's a quick repro term session:

![react-redux-starter-kit--node_modules-in-path-webpack-fails](https://user-images.githubusercontent.com/373565/27434241-5b331da2-5758-11e7-8524-a9748a019a09.png)

Or try this in a term:
```bash
# Assuming working directory is a git clone of the starter kit
λ mkdir node_modules--matches
λ cd ..
λ mv react-redux-starter-kit\ node_modules--matches\
λ cd node_modules--matches\react-redux-starter-kit--clean\
λ npm run compile

=>
clean\src\main.js Unexpected token (19:4)
You may need an appropriate loader to handle this file type.
|
|   ReactDOM.render(
|     <App store={store} routes={routes} />,
|     MOUNT_NODE
|   )
 @ multi ./src/main webpack-hot-middleware/client.js?path=/__webpack_hmr
× Compiler encountered errors. Error: Webpack compiler encountered errors
```

P.S.: Sorry for missing the "No capitalization on first letter" on the commit/contributing styleguide.