### PR TITLE
Make generate route components conveniently.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,33 @@
+module.exports = function (grunt) {
+  grunt.loadNpmTasks('grunt-contrib-copy')
+
+  var moduleName = grunt.option('name') || 'Test'
+  var moduleNameUpper = moduleName.toUpperCase()
+  var moduleNameCapital = moduleName.charAt(0).toUpperCase() + moduleName.slice(1)
+  var moduleNameCamel = moduleName.charAt(0).toLowerCase() + moduleName.slice(1)
+
+  // Project configuration.
+  grunt.initConfig({
+    copy: {
+      main: {
+        expand: true,
+        cwd: 'src/routes/Home',
+        src: ['**'],
+        dest: 'src/routes/' + moduleNameCapital + '/',
+        rename: function (dest, src) {
+          return dest + src.replace(/Home/g, moduleNameCapital)
+        },
+        options: {
+          process: function (content, srcpath) {
+            return content
+              .replace(/Home/g, moduleNameCapital)
+              .replace(/HOME/g, moduleNameUpper)
+              .replace(/home/g, moduleNameCamel)
+          },
+        },
+      },
+    },
+  })
+  // tasks
+  grunt.registerTask('createModule', ['copy'])
+}

--- a/package.json
+++ b/package.json
@@ -69,6 +69,8 @@
     "figures": "^2.0.0",
     "file-loader": "^0.11.1",
     "fs-extra": "^3.0.1",
+    "grunt": "^1.0.1",
+    "grunt-contrib-copy": "^1.0.0",
     "html-webpack-plugin": "^2.24.1",
     "karma": "^1.7.0",
     "karma-coverage": "^1.1.1",


### PR DESCRIPTION
- 1) To quick create a module you can run: grunt createModule --name=<moduleName>; or just follow blow steps
- 2)	Copy a template module folder that named “Home”, rename it to your module name, such as “Xxx”
- 3)	In components/ folder, change the root view name from ‘HomeView.js’ to what you wanted (such as ‘XxxView.js’), change the sass file name from ‘HomeView.scss’ (such as ‘XxxView.scss’) to what you wanted. Change the view name in below line:
